### PR TITLE
fix(hdot): aria attributes now serialize properly

### DIFF
--- a/packages/hdot/src/hdot.ts
+++ b/packages/hdot/src/hdot.ts
@@ -24,6 +24,14 @@ export const h: H = new Proxy(new PrivateState() as unknown as H, {
   },
 });
 
+const getAttributeName = (rawName) => {
+  let name = rawName;
+  if (name.length > 4 && (name.startsWith("data") || name.startsWith("aria"))) {
+    name = name.slice(0, 4) + '-' + name.slice(4);
+  }
+  return name.toLowerCase();
+}
+
 class Hdot extends Function {
   private htmlString: string = "";
 
@@ -42,14 +50,7 @@ class Hdot extends Function {
           return Reflect.get(target, key, reciever);
         }
         return (args: any) => {
-          let k = key;
-          if (k === "className") {
-            k = "class";
-          }
-          if (k.startsWith("data") && k.length > 4) {
-            k = "data-" + k.slice(4);
-          }
-          k = k.toLowerCase();
+          let k = getAttributeName(key);
 
           let a = args;
           for (const plugin of h["_plugins"]) {

--- a/packages/hdot/test/hdot.test.ts
+++ b/packages/hdot/test/hdot.test.ts
@@ -43,4 +43,13 @@ test("attributes", () => {
   );
 });
 
+test("data attributes", () => {
+  assert.equal(h.div.dataName('test123')(), `<div data-name="test123"></div>`);
+});
+
+test("aria attributes", () => {
+  assert.equal(h.div.ariaLabel('test123')(), `<div aria-label="test123"></div>`);
+  assert.equal(h.div.ariaLabel('test123').ariaChecked('false')(), `<div aria-label="test123" aria-checked="false"></div>`);
+});
+
 test.run();


### PR DESCRIPTION
Fixes an issue where aria attributes were not properly converting to kebab case upon serialization. Resolves #2.

Before:
```js
h.div.ariaLabel("test123") === `<div arialabel="test123"></div>`
```
Now:
```js
h.div.ariaLabel("test123") === `<div aria-label="test123"></div>`
```
Unit test suite "aria attributes" was added for this change.