### PR TITLE
chore(validate): move hdot to devDeps

### DIFF
--- a/packages/plugins/validate/package.json
+++ b/packages/plugins/validate/package.json
@@ -31,11 +31,11 @@
   "dependencies": {
     "@markuplint/html-spec": "^2.4.0",
     "@markuplint/ml-spec": "^2.0.1",
-    "@markuplint/types": "^2.0.0",
-    "hdot": "^0.0.5"
+    "@markuplint/types": "^2.0.0"
   },
   "devDependencies": {
     "tsm": "^2.2.1",
-    "uvu": "^0.5.3"
+    "uvu": "^0.5.3",
+    "hdot": "^0.0.5"
   }
 }

--- a/packages/plugins/validate/src/validate.ts
+++ b/packages/plugins/validate/src/validate.ts
@@ -1,4 +1,4 @@
-import { Plugin } from "hdot";
+import type { Plugin } from "hdot";
 import { check } from "@markuplint/types";
 import { getSpec, getAttrSpecs } from "@markuplint/ml-spec";
 import * as htmlSpecDef from "@markuplint/html-spec";


### PR DESCRIPTION
The validate plugin only relies on `hdot` for a type import, so it should be listed in `devDependencies` instead of `dependencies`.