### PR TITLE
fix(hdot): call return type is now string

### DIFF
--- a/packages/hdot/src/types/generate.js
+++ b/packages/hdot/src/types/generate.js
@@ -85,7 +85,7 @@ const writeGlobalAttributes = (content, htmlSpec) => {
     "[dataAttribute: `data${string}`]",
     `(value: string | boolean | number) => HTMLElements[TagName]`
   );
-  htmlDef.addProperty(`(...children: children)`, `HTMLElements[TagName]`);
+  htmlDef.addProperty(`(...children: children)`, `string`);
   content.push(htmlDef.toString());
 
   const ariaDef = new TypeDef(

--- a/packages/hdot/src/types/html.ts
+++ b/packages/hdot/src/types/html.ts
@@ -349,7 +349,7 @@ type GlobalHTMLAttributes<TagName extends keyof HTMLElements> = {
   /** @deprecated @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-xml:space */
   "xml:space": (value: "default" | "preserve") => HTMLElements[TagName];
   [dataAttribute: `data${string}`]: (value: string | boolean | number) => HTMLElements[TagName];
-  (...children: children): HTMLElements[TagName];
+  (...children: children): string;
 };
 
 type GlobalAriaAttributes<TagName extends keyof HTMLElements> = {


### PR DESCRIPTION
Calling an element returns a string--the type def should reflect this. This error was introduced when refactoring the type generation logic.