### PR TITLE
feat(all): rewrite internals to use tree data structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "size-limit": [
     {
-      "limit": "1 kb",
+      "limit": "1.5 kb",
       "path": "./packages/hdot/lib/hdot.js"
     },
     {

--- a/packages/docs/.eleventy.js
+++ b/packages/docs/.eleventy.js
@@ -1,22 +1,16 @@
+//@ts-check
 const pluginSyntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
-const { h, setPlugins } = require('hdot');
-
-setPlugins(h, [
-  {
-    attribute(tagName, key, args) {
-      if (tagName !== 'a' || key !== 'href' || args.includes('://hdot.dev')) {
-        return [key, args];
-      }
-      return [` target="_blank" rel="noopener noreferrer" ` + key, args]
-    }
-  }
-])
+const automaticNoopener = require('eleventy-plugin-automatic-noopener');
 
 module.exports = function (eleventyConfig) {
-
   eleventyConfig.addPassthroughCopy({ "src/css": "css" });
   eleventyConfig.addPassthroughCopy({ "src/img": "img" });
   eleventyConfig.addPlugin(pluginSyntaxHighlight);
+  eleventyConfig.addPlugin(automaticNoopener, {
+    elements: ['a', 'area', 'form'],
+    noopener: true,
+    noreferrer: true,
+  });
 
   return {
     dir: {

--- a/packages/docs/package-lock.json
+++ b/packages/docs/package-lock.json
@@ -1,17 +1,21 @@
 {
-  "name": "docs",
+  "name": "@hdot/docs",
   "version": "0.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.0.2",
+      "name": "@hdot/docs",
+      "version": "0.0.7",
       "license": "MIT",
+      "dependencies": {
+        "eleventy-plugin-automatic-noopener": "^2.0.2"
+      },
       "devDependencies": {
         "@11ty/eleventy": "^1.0.0",
         "@11ty/eleventy-plugin-syntaxhighlight": "^4.0.0",
-        "@hdot/validate": "^0.0.2",
-        "hdot": "^0.0.2",
+        "@hdot/validate": "^0.0.7",
+        "hdot": "^0.0.7",
         "tsm": "^2.2.1",
         "uvu": "^0.5.3"
       }
@@ -42,13 +46,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@11ty/dependency-tree/-/dependency-tree-2.0.0.tgz",
       "integrity": "sha512-tYrGX3Tvccufy2jaYDkYpjBmVP1LeQq6b/d0r4GYThTXL4f3ZR7yMAl/0r8h9xvnsP+gkO53wfnV7s8cXcCtEg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@11ty/eleventy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-1.0.0.tgz",
       "integrity": "sha512-UMZghkMFwovu3Vh6DzjJ9GbcBnlE3nydGmLAti2AB1d6etQE+jXgfuHNxOyV1em33ywsBgGUCtLmLHaaTSU+Nw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@11ty/dependency-tree": "^2.0.0",
         "@iarna/toml": "^2.2.5",
@@ -112,7 +116,7 @@
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
       "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -121,7 +125,7 @@
       "version": "7.17.8",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
       "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -133,7 +137,7 @@
       "version": "7.17.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
       "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.16.7",
         "to-fast-properties": "^2.0.0"
@@ -143,22 +147,21 @@
       }
     },
     "node_modules/@hdot/validate": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@hdot/validate/-/validate-0.0.2.tgz",
-      "integrity": "sha512-96DooZ9sXXBBiQ80b24QJ94rU5o9PoGhqI2bqELti4MciIZkj8rUcjpay1jIGwTk6CiQrjvjbpMeT4Fl63eb+A==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@hdot/validate/-/validate-0.0.7.tgz",
+      "integrity": "sha512-L47rQlnuC4lECxjm7uylcIfpbVQPQWvy1W8/Y1INSn56e5D7uo0EOXCKfNNt3upu7GBLC9mVoF1RbV5bNUqykQ==",
       "dev": true,
       "dependencies": {
         "@markuplint/html-spec": "^2.4.0",
         "@markuplint/ml-spec": "^2.0.1",
-        "@markuplint/types": "^2.0.0",
-        "hdot": "^0.0.2"
+        "@markuplint/types": "^2.0.0"
       }
     },
     "node_modules/@iarna/toml": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@markuplint/html-spec": {
       "version": "2.4.0",
@@ -195,7 +198,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -208,7 +211,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 8"
       }
@@ -217,7 +220,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -230,7 +233,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-1.1.2.tgz",
       "integrity": "sha512-V9nR/W0Xd9TSGXpZ4iFUcFGhuOJtZX82Fzxj1YISlbSgKvIiNa7eLEZrT0vAraPOt++KHauIVNYgGRgjc13dXA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@sindresorhus/transliterate": "^0.1.1",
         "escape-string-regexp": "^4.0.0"
@@ -246,7 +249,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@sindresorhus/transliterate/-/transliterate-0.1.2.tgz",
       "integrity": "sha512-5/kmIOY9FF32nicXH+5yLNTX4NJ4atl7jRgqAJuIn/iyDFXBktOKDxCvyGE/EzmF4ngSUvjXxQUQlQiZ5lfw+w==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "escape-string-regexp": "^2.0.0",
         "lodash.deburr": "^4.1.0"
@@ -262,7 +265,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -271,7 +274,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@socket.io/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
       "integrity": "sha512-dOlCBKnDw4iShaIsH/bxujKTM18+2TOAsYz+KSc11Am38H4q5Xw8Bbz97ZYdrVNM+um3p7w86Bvvmcn9q+5+eQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -280,55 +283,55 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.0.0.tgz",
       "integrity": "sha512-2pTGuibAXJswAPJjaKisthqS/NOK5ypG4LYT6tEAV0S/mxW0zOIvYvGK0V8w8+SHxAm6vRMSjqSalFXeBAqs+Q==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/component-emitter": {
       "version": "1.2.11",
       "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
       "integrity": "sha512-SRXjM+tfsSlA9VuG8hGO2nft2p8zjXCK1VcC6N4NXbBbYbSia9kzCChYQajIjzIqOOOuh5Ock6MmV2oux4jDZQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/cookie": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
       "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/cors": {
       "version": "2.8.12",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
       "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/node": {
       "version": "17.0.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
       "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/a-sync-waterfall": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
       "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
       "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
@@ -341,7 +344,7 @@
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -353,7 +356,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -362,7 +365,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -374,7 +377,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
       "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -387,7 +390,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
@@ -396,7 +399,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
       "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -405,7 +408,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -414,7 +417,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -423,7 +426,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
       "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -432,25 +435,25 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/assert-never": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
       "integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/async": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
       "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/async-each-series": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
       "integrity": "sha1-dhfBkXQB/Yykooqtzj266Yr+tDI=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -459,7 +462,7 @@
       "version": "0.21.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
       "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "follow-redirects": "^1.14.0"
       }
@@ -468,7 +471,7 @@
       "version": "3.0.0-canary-5",
       "resolved": "https://registry.npmjs.org/babel-walk/-/babel-walk-3.0.0-canary-5.tgz",
       "integrity": "sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@babel/types": "^7.9.6"
       },
@@ -480,19 +483,19 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
       "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/base64id": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
       "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": "^4.5.0 || >= 5.9"
       }
@@ -501,7 +504,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/bcp-47": {
       "version": "1.0.8",
@@ -522,7 +525,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -537,7 +540,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -547,7 +550,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "fill-range": "^7.0.1"
       },
@@ -559,7 +562,7 @@
       "version": "2.27.9",
       "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.27.9.tgz",
       "integrity": "sha512-3zBtggcaZIeU9so4ja9yxk7/CZu9B3DOL6zkxFpzHCHsQmkGBPVXg61jItbeoa+WXgNLnr1sYES/2yQwyEZ2+w==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "browser-sync-client": "^2.27.9",
         "browser-sync-ui": "^2.27.9",
@@ -603,7 +606,7 @@
       "version": "2.27.9",
       "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.27.9.tgz",
       "integrity": "sha512-FHW8kydp7FXo6jnX3gXJCpHAHtWNLK0nx839nnK+boMfMI1n4KZd0+DmTxHBsHsF3OHud4V4jwoN8U5HExMIdQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "etag": "1.8.1",
         "fresh": "0.5.2",
@@ -618,7 +621,7 @@
       "version": "2.27.9",
       "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.27.9.tgz",
       "integrity": "sha512-rsduR2bRIwFvM8CX6iY/Nu5aWub0WB9zfSYg9Le/RV5N5DEyxJYey0VxdfWCnzDOoelassTDzYQo+r0iJno3qw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "async-each-series": "0.1.1",
         "connect-history-api-fallback": "^1",
@@ -632,19 +635,19 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/bs-recipes/-/bs-recipes-1.3.4.tgz",
       "integrity": "sha1-DS1NSKcYyMBEdp/cT4lZLci2lYU=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/bs-snippet-injector": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/bs-snippet-injector/-/bs-snippet-injector-2.0.1.tgz",
       "integrity": "sha1-YbU5PxH1JVntEgaTEANDtu2wTdU=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -653,7 +656,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -666,7 +669,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -680,7 +683,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -689,7 +692,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
       "integrity": "sha1-x84o821LzZdE5f/CxfzeHHMmH8A=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "is-regex": "^1.0.3"
       }
@@ -698,7 +701,7 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -725,7 +728,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -736,7 +739,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -745,13 +748,13 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/commander": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
       "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 6"
       }
@@ -760,19 +763,19 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/condense-newlines": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/condense-newlines/-/condense-newlines-0.2.1.tgz",
       "integrity": "sha1-PemFVTE5R10yUCyDsC9gaE0kxV8=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "extend-shallow": "^2.0.1",
         "is-whitespace": "^0.3.0",
@@ -786,7 +789,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "is-buffer": "^1.1.5"
       },
@@ -798,7 +801,7 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
       "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ini": "^1.3.4",
         "proto-list": "~1.2.1"
@@ -808,7 +811,7 @@
       "version": "3.6.6",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
       "integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "debug": "2.6.9",
         "finalhandler": "1.1.0",
@@ -823,7 +826,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
       "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -832,7 +835,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -841,13 +844,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/constantinople": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
       "integrity": "sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@babel/parser": "^7.6.0",
         "@babel/types": "^7.6.1"
@@ -857,7 +860,7 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
       "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -866,7 +869,7 @@
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
       "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "object-assign": "^4",
         "vary": "^1"
@@ -926,7 +929,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -943,7 +946,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -952,7 +955,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
       "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -970,13 +973,13 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/dev-ip": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz",
       "integrity": "sha1-p2o+0YVb56ASu4rBbLgPPADcKPA=",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "dev-ip": "lib/dev-ip.js"
       },
@@ -997,19 +1000,18 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/doctypes": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
       "integrity": "sha1-6oCxBqh1OHdOijpKWv4pPeSJ4Kk=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/dom-serializer": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
       "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
-      "dev": true,
       "dependencies": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.2.0",
@@ -1023,7 +1025,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
       "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1035,7 +1036,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
       "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-      "dev": true,
       "dependencies": {
         "domelementtype": "^2.2.0"
       },
@@ -1050,7 +1050,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
       "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-      "dev": true,
       "dependencies": {
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",
@@ -1064,7 +1063,7 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.4.tgz",
       "integrity": "sha512-8cAwm6md1YTiPpOvDULYJL4ZS6WfM5/cTeVVh4JsvyYZAoqlRVUpHL9Gr5Fy7HA6xcSZicUia3DeAgO3Us8E+Q==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "lodash": "^4.17.10"
       },
@@ -1076,7 +1075,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-3.1.0.tgz",
       "integrity": "sha512-/snsn2JqBtUSSstEl4R0RKjkisGHAhvYj89i7r3ytNUKW12y178KDZwXLXIgwDqLW6E/VRMT9qfld7wvFae8bQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "tfunk": "^4.0.0"
       },
@@ -1088,7 +1087,7 @@
       "version": "0.15.3",
       "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
       "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "commander": "^2.19.0",
         "lru-cache": "^4.1.5",
@@ -1103,13 +1102,13 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/editorconfig/node_modules/semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -1118,13 +1117,13 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/ejs": {
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.6.tgz",
       "integrity": "sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "jake": "^10.6.1"
       },
@@ -1135,17 +1134,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eleventy-plugin-automatic-noopener": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eleventy-plugin-automatic-noopener/-/eleventy-plugin-automatic-noopener-2.0.2.tgz",
+      "integrity": "sha512-uMHHAG7SUwiuNTd1yPTe8ijIjyTghV9JVXJ/vOUdbu+r3O0aJJ3ARsKAz83GMdSFivrY4XOnenlCOXeovGNBQw==",
+      "dependencies": {
+        "posthtml": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "@11ty/eleventy": "*"
+      },
+      "peerDependenciesMeta": {
+        "@11ty/eleventy": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -1154,7 +1172,7 @@
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.1.3.tgz",
       "integrity": "sha512-rqs60YwkvWTLLnfazqgZqLa/aKo+9cueVfEi/dZ8PyGyaf8TLOxj++4QMIgeG3Gn0AhrWiFXvghsoY9L9h25GA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/cookie": "^0.4.1",
         "@types/cors": "^2.8.12",
@@ -1175,7 +1193,7 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.1.1.tgz",
       "integrity": "sha512-V05mmDo4gjimYW+FGujoGmmmxRaDsrVr7AXA3ZIfa04MWM1jOfZfUwou0oNqhNwy/votUDvGDt4JA4QF4e0b4g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@socket.io/component-emitter": "~3.0.0",
         "debug": "~4.3.1",
@@ -1192,7 +1210,7 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.3.tgz",
       "integrity": "sha512-BtQxwF27XUNnSafQLvDi0dQ8s3i6VgzSoQMJacpIcGNrlUdfHSKbgm3jmjCVvQluGzqwujQMPAoMai3oYSTurg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@socket.io/base64-arraybuffer": "~1.0.2"
       },
@@ -1204,7 +1222,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
       "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
@@ -1213,7 +1230,7 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
       "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "prr": "~1.0.1"
       },
@@ -1580,7 +1597,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=6"
       }
@@ -1589,13 +1606,13 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=10"
       },
@@ -1607,7 +1624,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -1620,7 +1637,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1629,13 +1646,13 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "is-extendable": "^0.1.0"
       },
@@ -1647,7 +1664,7 @@
       "version": "3.2.11",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
       "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -1663,7 +1680,7 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
       "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -1672,7 +1689,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.2.tgz",
       "integrity": "sha512-z7O0IS8Plc39rTCq6i6iHxk43duYOn8uFJiWSewIq0Bww1RNybVHSCjahmcC87ZqAm4OTvFzlzeGu3XAzG1ctQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "minimatch": "^3.0.4"
       }
@@ -1681,7 +1698,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -1693,7 +1710,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
       "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.1",
@@ -1711,7 +1728,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -1720,13 +1737,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/follow-redirects": {
       "version": "1.14.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
       "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -1746,7 +1763,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1755,7 +1772,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
       "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^3.0.0",
@@ -1766,7 +1783,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -1786,13 +1803,13 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -1801,7 +1818,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
       "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -1815,7 +1832,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1835,7 +1852,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -1847,13 +1864,13 @@
       "version": "4.2.9",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
       "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/gray-matter": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
       "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "js-yaml": "^3.13.1",
         "kind-of": "^6.0.2",
@@ -1868,13 +1885,13 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/hamljs/-/hamljs-0.6.2.tgz",
       "integrity": "sha1-e3EWz22+cnjkKz9u+HJaM+F3yOM=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/handlebars": {
       "version": "4.7.7",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
       "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
@@ -1895,7 +1912,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -1907,7 +1924,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -1919,7 +1936,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1928,13 +1945,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
       "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=4"
       }
@@ -1943,7 +1960,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -1955,7 +1972,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
       "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "has-symbols": "^1.0.2"
       },
@@ -1967,9 +1984,9 @@
       }
     },
     "node_modules/hdot": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/hdot/-/hdot-0.0.2.tgz",
-      "integrity": "sha512-1jYEmSuvUXIsZUspILm5BYmRII+dOwmvM+QYmq6AiN6F6mYp72jNlLImoIgq5IIJcz5RYwvzbxXFaYC+GjgCzw==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/hdot/-/hdot-0.0.7.tgz",
+      "integrity": "sha512-gCSpxQdh9GhpVSPwWLyKt7Ok4941tyXYPmp11hJ32tEYABbBuQNQ1n5FKKTRbAmngyDPS8yBUdNeht09pp/gqw==",
       "dev": true
     },
     "node_modules/html-escaper": {
@@ -1982,7 +1999,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
       "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
-      "dev": true,
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -2001,7 +2017,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
       "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
-      "dev": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -2013,7 +2028,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
       "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "depd": "2.0.0",
         "inherits": "2.0.4",
@@ -2029,7 +2044,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2038,7 +2053,7 @@
       "version": "1.18.1",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
       "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
@@ -2052,7 +2067,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -2064,7 +2079,7 @@
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
       "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2073,7 +2088,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -2083,13 +2098,13 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/is-alphabetical": {
       "version": "1.0.4",
@@ -2119,7 +2134,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -2131,13 +2146,13 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/is-core-module": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
       "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -2159,7 +2174,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
       "integrity": "sha512-zMIXX63sxzG3XrkHkrAPvm/OVZVSCPNkwMHU8oTX7/U3AL78I0QXCEICXUM13BIa8TYGZ68PiTKfQz3yaTNr4A==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "acorn": "^7.1.1",
         "object-assign": "^4.1.1"
@@ -2169,7 +2184,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2178,7 +2193,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2187,7 +2202,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -2196,7 +2211,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -2204,11 +2219,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-json": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-json/-/is-json-2.0.1.tgz",
+      "integrity": "sha1-a+Fm0USCihMdaGiRuYPfYsOUkf8="
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -2217,7 +2237,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz",
       "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "lodash.isfinite": "^3.3.2"
       }
@@ -2226,13 +2246,13 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
       "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -2248,7 +2268,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/is-whitespace/-/is-whitespace-0.3.0.tgz",
       "integrity": "sha1-Fjnssb4DauxppUy7QBz77XEUq38=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2257,7 +2277,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
       "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=4"
       }
@@ -2266,7 +2286,7 @@
       "version": "10.8.2",
       "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.2.tgz",
       "integrity": "sha512-eLpKyrfG3mzvGE2Du8VoPbeSkRry093+tyNjdYaBbJS9v17knImYGNXQCUV0gLxQtF82m3E8iRb/wdSQZLoq7A==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "async": "0.9.x",
         "chalk": "^2.4.2",
@@ -2284,7 +2304,7 @@
       "version": "1.14.0",
       "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.0.tgz",
       "integrity": "sha512-yuck9KirNSCAwyNJbqW+BxJqJ0NLJ4PwBUzQQACl5O3qHMBXVkXb/rD0ilh/Lat/tn88zSZ+CAHOlk0DsY7GuQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "config-chain": "^1.1.12",
         "editorconfig": "^0.15.3",
@@ -2304,13 +2324,13 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
       "integrity": "sha1-Fzb939lyTyijaCrcYjCufk6Weds=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -2323,7 +2343,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
       "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
-      "dev": true,
+      "devOptional": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -2332,7 +2352,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-1.0.0.tgz",
       "integrity": "sha1-7Yvwkh4vPx7U1cGkT2hwntJHIsM=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "is-promise": "^2.0.0",
         "promise": "^7.0.1"
@@ -2342,7 +2362,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/junk/-/junk-1.0.3.tgz",
       "integrity": "sha1-h75jSIZJy9ym9Tqzm+yczSNH9ZI=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2351,7 +2371,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2360,7 +2380,7 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
       "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=6"
       }
@@ -2378,7 +2398,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
       "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/linkedom": {
       "version": "0.13.7",
@@ -2397,7 +2417,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
       "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "uc.micro": "^1.0.1"
       }
@@ -2406,7 +2426,7 @@
       "version": "9.36.0",
       "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-9.36.0.tgz",
       "integrity": "sha512-HbU4xBsY1r3ZEORTgPsiluXsOtMx8iI0MqTsPejgIk+sIgta5wQUYsoQgUPuGKWVHKKKMO9PidiMEPKlePl8rg==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "liquid": "bin/liquid.js",
         "liquidjs": "bin/liquid.js"
@@ -2423,7 +2443,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-2.0.2.tgz",
       "integrity": "sha512-n418Cn5ynvJd7m/N1d9WVJISLJF/ellZnfsLnx8WBWGzxv/ntNcFkJ1o6se5quUhCplfLGBNL5tYHiq5WF3Nug==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "axios": "0.21.4",
         "debug": "4.3.2",
@@ -2441,7 +2461,7 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
       "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -2458,7 +2478,7 @@
       "version": "17.1.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.1.tgz",
       "integrity": "sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -2476,7 +2496,7 @@
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=10"
       }
@@ -2485,25 +2505,25 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/lodash.deburr": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-4.1.0.tgz",
       "integrity": "sha1-3bG7s+8HRYwBd7oH3hRCLLAz/5s=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/lodash.isfinite": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
       "integrity": "sha1-+4m2WpqAKBgz8LdHizpRBPiY67M=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/lru-cache": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
       "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
@@ -2513,7 +2533,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.3.1.tgz",
       "integrity": "sha512-I8vnjOmhXsMSlNMZlMkSOvgrxKJl0uOsEzdGgGNZuZPaS9KlefpE9KV95QFftlJSC+1UyCC9/I69R02cz/zcCA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=12"
       }
@@ -2522,7 +2542,7 @@
       "version": "12.3.2",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
       "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "~2.1.0",
@@ -2538,13 +2558,13 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/maximatch": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/maximatch/-/maximatch-0.1.0.tgz",
       "integrity": "sha1-hs2NawTJ8wfAWmuUGZBtA2D7E6I=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "array-differ": "^1.0.0",
         "array-union": "^1.0.1",
@@ -2559,7 +2579,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
       "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2568,7 +2588,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "array-uniq": "^1.0.1"
       },
@@ -2580,7 +2600,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2595,13 +2615,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
       "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 8"
       }
@@ -2610,7 +2630,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
       "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "braces": "^3.0.1",
         "picomatch": "^2.2.3"
@@ -2623,7 +2643,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
       "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "mime": "cli.js"
       }
@@ -2632,7 +2652,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2641,7 +2661,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -2653,7 +2673,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -2665,19 +2685,19 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/mitt": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.2.0.tgz",
       "integrity": "sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/mkdirp": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "minimist": "^1.2.5"
       },
@@ -2689,7 +2709,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
       "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/mri": {
       "version": "1.2.0",
@@ -2704,13 +2724,13 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/multimatch": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-5.0.0.tgz",
       "integrity": "sha512-ypMKuglUrZUD99Tk2bUQ+xNQj43lPEfAeX2o9cTteAmShXy2VHDJpuwu1o0xqoKCt9jLVAvwyFKdLTPXKAfJyA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/minimatch": "^3.0.3",
         "array-differ": "^3.0.0",
@@ -2729,7 +2749,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
       "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "mustache": "bin/mustache"
       }
@@ -2738,7 +2758,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2747,13 +2767,13 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/nopt": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
       "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "abbrev": "1"
       },
@@ -2768,7 +2788,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2789,7 +2809,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.3.tgz",
       "integrity": "sha512-psb6xjLj47+fE76JdZwskvwG4MYsQKXUtMsPh6U0YMvmyjRtKRFcxnlXGWglNybtNTNVmGdp94K62/+NjF5FDQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "a-sync-waterfall": "^1.0.0",
         "asap": "^2.0.3",
@@ -2814,7 +2834,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2823,7 +2843,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -2835,7 +2855,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -2844,13 +2864,13 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz",
       "integrity": "sha1-OHW0sO96UsFW8NtB1GCduw+Us4c=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/opn": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
       "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "is-wsl": "^1.1.0"
       },
@@ -2862,19 +2882,19 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
       "integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/parseuri": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
       "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2883,7 +2903,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2892,19 +2912,19 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/path-to-regexp": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz",
       "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -2916,7 +2936,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2925,7 +2945,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
       "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "semver-compare": "^1.0.0"
       }
@@ -2934,7 +2954,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.1.1.tgz",
       "integrity": "sha1-6rtAnk3iSVD1oqUW01rnaTQ/u5Y=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "async": "1.5.2",
         "is-number-like": "^1.0.3"
@@ -2948,13 +2968,47 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-      "dev": true
+      "devOptional": true
+    },
+    "node_modules/posthtml": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.6.tgz",
+      "integrity": "sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==",
+      "dependencies": {
+        "posthtml-parser": "^0.11.0",
+        "posthtml-render": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/posthtml-parser": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.11.0.tgz",
+      "integrity": "sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==",
+      "dependencies": {
+        "htmlparser2": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/posthtml-render": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
+      "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
+      "dependencies": {
+        "is-json": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/pretty": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pretty/-/pretty-2.0.0.tgz",
       "integrity": "sha1-rbx5YLe7/iiaVX3F9zdhmiINBqU=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "condense-newlines": "^0.2.1",
         "extend-shallow": "^2.0.1",
@@ -2977,7 +3031,7 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "asap": "~2.0.3"
       }
@@ -2986,25 +3040,25 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/pug": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/pug/-/pug-3.0.2.tgz",
       "integrity": "sha512-bp0I/hiK1D1vChHh6EfDxtndHji55XP/ZJKwsRqrz6lRia6ZC2OZbdAymlxdVFwd1L70ebrVJw4/eZ79skrIaw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "pug-code-gen": "^3.0.2",
         "pug-filters": "^4.0.0",
@@ -3020,7 +3074,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-3.0.0.tgz",
       "integrity": "sha512-azINV9dUtzPMFQktvTXciNAfAuVh/L/JCl0vtPCwvOA21uZrC08K/UnmrL+SXGEVc1FwzjW62+xw5S/uaLj6cA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "constantinople": "^4.0.1",
         "js-stringify": "^1.0.2",
@@ -3031,7 +3085,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.2.tgz",
       "integrity": "sha512-nJMhW16MbiGRiyR4miDTQMRWDgKplnHyeLvioEJYbk1RsPI3FuA3saEP8uwnTb2nTJEKBU90NFVWJBk4OU5qyg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "constantinople": "^4.0.1",
         "doctypes": "^1.1.0",
@@ -3047,13 +3101,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-2.0.0.tgz",
       "integrity": "sha512-sjiUsi9M4RAGHktC1drQfCr5C5eriu24Lfbt4s+7SykztEOwVZtbFk1RRq0tzLxcMxMYTBR+zMQaG07J/btayQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/pug-filters": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
       "integrity": "sha512-yeNFtq5Yxmfz0f9z2rMXGw/8/4i1cCFecw/Q7+D0V2DdtII5UvqE12VaZ2AY7ri6o5RNXiweGH79OCq+2RQU4A==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "constantinople": "^4.0.1",
         "jstransformer": "1.0.0",
@@ -3066,7 +3120,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-5.0.1.tgz",
       "integrity": "sha512-0I6C62+keXlZPZkOJeVam9aBLVP2EnbeDw3An+k0/QlqdwH6rv8284nko14Na7c0TtqtogfWXcRoFE4O4Ff20w==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "character-parser": "^2.2.0",
         "is-expression": "^4.0.0",
@@ -3077,7 +3131,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
       "integrity": "sha512-gjD1yzp0yxbQqnzBAdlhbgoJL5qIFJw78juN1NpTLt/mfPJ5VgC4BvkoD3G23qKzJtIIXBbcCt6FioLSFLOHdw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "pug-error": "^2.0.0",
         "pug-walk": "^2.0.0"
@@ -3087,7 +3141,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pug-load/-/pug-load-3.0.0.tgz",
       "integrity": "sha512-OCjTEnhLWZBvS4zni/WUMjH2YSUosnsmjGBB1An7CsKQarYSWQ0GCVyd4eQPMFJqZ8w9xgs01QdiZXKVjk92EQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "object-assign": "^4.1.1",
         "pug-walk": "^2.0.0"
@@ -3097,7 +3151,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
       "integrity": "sha512-ukiYM/9cH6Cml+AOl5kETtM9NR3WulyVP2y4HOU45DyMim1IeP/OOiyEWRr6qk5I5klpsBnbuHpwKmTx6WURnw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "pug-error": "^2.0.0",
         "token-stream": "1.0.0"
@@ -3107,13 +3161,13 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-3.0.1.tgz",
       "integrity": "sha512-L50zbvrQ35TkpHwv0G6aLSuueDRwc/97XdY8kL3tOT0FmhgG7UypU3VztfV/LATAvmUfYi4wNxSajhSAeNN+Kg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/pug-strip-comments": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
       "integrity": "sha512-zo8DsDpH7eTkPHCXFeAk1xZXJbyoTfdPlNR0bK7rpOMuhBYb0f5qUVCO1xlsitYd3w5FQTK7zpNVKb3rZoUrrQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "pug-error": "^2.0.0"
       }
@@ -3122,13 +3176,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-2.0.0.tgz",
       "integrity": "sha512-yYELe9Q5q9IQhuvqsZNwA5hfPkMJ8u92bQLIMcsMxf/VADjNtEYptU+inlufAFYcWdHlwNfZOEnOOQrZrcyJCQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/qs": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
       "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -3137,7 +3191,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -3157,7 +3211,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3166,7 +3220,7 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
       "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
@@ -3181,7 +3235,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -3193,7 +3247,7 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/recursive-copy/-/recursive-copy-2.0.14.tgz",
       "integrity": "sha512-K8WNY8f8naTpfbA+RaXmkaQuD1IeW9EgNEfyGxSqqTQukpVtoOKros9jUqbpEsSw59YOmpd8nCBgtqJZy5nvog==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "errno": "^0.1.2",
         "graceful-fs": "^4.1.4",
@@ -3210,7 +3264,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3219,13 +3273,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/resolve": {
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
       "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "is-core-module": "^2.8.1",
         "path-parse": "^1.0.7",
@@ -3242,7 +3296,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.2.tgz",
       "integrity": "sha1-sSTeXE+6/LpUH0j/pzlw9KpFa08=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "debug": "^2.2.0",
         "minimatch": "^3.0.2"
@@ -3255,7 +3309,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -3264,13 +3318,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -3280,7 +3334,7 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -3292,7 +3346,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -3315,13 +3369,13 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
       "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/rxjs": {
       "version": "5.5.12",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
       "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "symbol-observable": "1.0.1"
       },
@@ -3345,13 +3399,13 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/section-matter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
       "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "extend-shallow": "^2.0.1",
         "kind-of": "^6.0.0"
@@ -3364,7 +3418,7 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -3379,13 +3433,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/semver/node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -3397,13 +3451,13 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/send": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
       "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "debug": "2.6.9",
         "depd": "~1.1.2",
@@ -3427,7 +3481,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -3436,7 +3490,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3445,7 +3499,7 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",
@@ -3460,25 +3514,25 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/send/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/send/node_modules/setprototypeof": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
       "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/send/node_modules/statuses": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
       "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3487,7 +3541,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "accepts": "~1.3.4",
         "batch": "0.6.1",
@@ -3505,7 +3559,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -3514,7 +3568,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3523,7 +3577,7 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",
@@ -3538,25 +3592,25 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/serve-index/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/serve-index/node_modules/setprototypeof": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
       "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/serve-index/node_modules/statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3565,7 +3619,7 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
@@ -3580,25 +3634,25 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
       "integrity": "sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/sigmund": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
       "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3607,7 +3661,7 @@
       "version": "1.6.5",
       "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.5.tgz",
       "integrity": "sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3616,7 +3670,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.4.1.tgz",
       "integrity": "sha512-s04vrBswdQBUmuWJuuNTmXUVJhP0cVky8bBDhdkf8y0Ptsu7fKU2LuLbts9g+pdmAdyMMn8F/9Mf1/wbtUN0fg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
@@ -3633,13 +3687,13 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.3.3.tgz",
       "integrity": "sha512-Qd/iwn3VskrpNO60BeRyCyr8ZWw9CPZyitW4AQwmRZ8zCiyDiL+znRnWX6tDHXnWn1sJrM1+b6Mn6wEDJJ4aYQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/socket.io-client": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.4.1.tgz",
       "integrity": "sha512-N5C/L5fLNha5Ojd7Yeb/puKcPWWcoB/A09fEjjNsg91EDVr5twk/OEyO6VT9dlLSUNY85NpW6KBhVMvaLKQ3vQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@socket.io/component-emitter": "~3.0.0",
         "backo2": "~1.0.2",
@@ -3656,7 +3710,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.1.2.tgz",
       "integrity": "sha512-j3kk71QLJuyQ/hh5F/L2t1goqzdTL0gvDzuhTuNSwihfuFUrcSji0qFZmJJPtG6Rmug153eOPsUizeirf1IIog==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@socket.io/component-emitter": "~3.0.0",
         "debug": "~4.3.1"
@@ -3669,7 +3723,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.4.tgz",
       "integrity": "sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/component-emitter": "^1.2.10",
         "component-emitter": "~1.3.0",
@@ -3683,7 +3737,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3692,13 +3746,13 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/statuses": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3707,7 +3761,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
       "integrity": "sha1-rdV8jXzHOoFjDTHNVdOWHPr7qcM=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "commander": "^2.2.0",
         "limiter": "^1.0.5"
@@ -3723,13 +3777,13 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -3743,7 +3797,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -3755,7 +3809,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
       "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3764,7 +3818,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -3776,7 +3830,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -3788,7 +3842,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
       "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3797,7 +3851,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/tfunk/-/tfunk-4.0.0.tgz",
       "integrity": "sha512-eJQ0dGfDIzWNiFNYFVjJ+Ezl/GmwHaFTBTjrtqNPW0S7cuVDBrZrmzUz6VkMeCR4DZFqhd4YtLwsw3i2wYHswQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "chalk": "^1.1.3",
         "dlv": "^1.1.3"
@@ -3807,7 +3861,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3816,7 +3870,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3825,7 +3879,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ansi-styles": "^2.2.1",
         "escape-string-regexp": "^1.0.2",
@@ -3841,7 +3895,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -3850,7 +3904,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -3862,7 +3916,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -3871,7 +3925,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=4"
       }
@@ -3880,7 +3934,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -3892,7 +3946,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -3901,7 +3955,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
       "integrity": "sha1-zCAOqyYT9BZtJ/+a/HylbUnfbrQ=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/tslib": {
       "version": "2.3.1",
@@ -3928,7 +3982,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.2.tgz",
       "integrity": "sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3947,7 +4001,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/uglify-js": {
       "version": "3.15.3",
@@ -3972,7 +4026,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -3981,7 +4035,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -3990,7 +4044,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -4017,7 +4071,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -4026,7 +4080,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
       "integrity": "sha1-YU9/v42AHwu18GYfWy9XhXUOTwk=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4041,7 +4095,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/with/-/with-7.0.2.tgz",
       "integrity": "sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@babel/parser": "^7.9.6",
         "@babel/types": "^7.9.6",
@@ -4056,13 +4110,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -4079,7 +4133,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -4094,7 +4148,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -4106,19 +4160,19 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/ws": {
       "version": "8.2.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
       "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -4139,7 +4193,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
       "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4148,7 +4202,7 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=10"
       }
@@ -4157,13 +4211,13 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/yargs": {
       "version": "17.3.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
       "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -4181,7 +4235,7 @@
       "version": "21.0.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
       "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=12"
       }
@@ -4190,7 +4244,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
-      "dev": true
+      "devOptional": true
     }
   },
   "dependencies": {
@@ -4198,13 +4252,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@11ty/dependency-tree/-/dependency-tree-2.0.0.tgz",
       "integrity": "sha512-tYrGX3Tvccufy2jaYDkYpjBmVP1LeQq6b/d0r4GYThTXL4f3ZR7yMAl/0r8h9xvnsP+gkO53wfnV7s8cXcCtEg==",
-      "dev": true
+      "devOptional": true
     },
     "@11ty/eleventy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-1.0.0.tgz",
       "integrity": "sha512-UMZghkMFwovu3Vh6DzjJ9GbcBnlE3nydGmLAti2AB1d6etQE+jXgfuHNxOyV1em33ywsBgGUCtLmLHaaTSU+Nw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@11ty/dependency-tree": "^2.0.0",
         "@iarna/toml": "^2.2.5",
@@ -4254,41 +4308,40 @@
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
       "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
-      "dev": true
+      "devOptional": true
     },
     "@babel/parser": {
       "version": "7.17.8",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
       "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==",
-      "dev": true
+      "devOptional": true
     },
     "@babel/types": {
       "version": "7.17.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
       "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.16.7",
         "to-fast-properties": "^2.0.0"
       }
     },
     "@hdot/validate": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@hdot/validate/-/validate-0.0.2.tgz",
-      "integrity": "sha512-96DooZ9sXXBBiQ80b24QJ94rU5o9PoGhqI2bqELti4MciIZkj8rUcjpay1jIGwTk6CiQrjvjbpMeT4Fl63eb+A==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@hdot/validate/-/validate-0.0.7.tgz",
+      "integrity": "sha512-L47rQlnuC4lECxjm7uylcIfpbVQPQWvy1W8/Y1INSn56e5D7uo0EOXCKfNNt3upu7GBLC9mVoF1RbV5bNUqykQ==",
       "dev": true,
       "requires": {
         "@markuplint/html-spec": "^2.4.0",
         "@markuplint/ml-spec": "^2.0.1",
-        "@markuplint/types": "^2.0.0",
-        "hdot": "^0.0.2"
+        "@markuplint/types": "^2.0.0"
       }
     },
     "@iarna/toml": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
-      "dev": true
+      "devOptional": true
     },
     "@markuplint/html-spec": {
       "version": "2.4.0",
@@ -4325,7 +4378,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -4335,13 +4388,13 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true
+      "devOptional": true
     },
     "@nodelib/fs.walk": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -4351,7 +4404,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-1.1.2.tgz",
       "integrity": "sha512-V9nR/W0Xd9TSGXpZ4iFUcFGhuOJtZX82Fzxj1YISlbSgKvIiNa7eLEZrT0vAraPOt++KHauIVNYgGRgjc13dXA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@sindresorhus/transliterate": "^0.1.1",
         "escape-string-regexp": "^4.0.0"
@@ -4361,7 +4414,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@sindresorhus/transliterate/-/transliterate-0.1.2.tgz",
       "integrity": "sha512-5/kmIOY9FF32nicXH+5yLNTX4NJ4atl7jRgqAJuIn/iyDFXBktOKDxCvyGE/EzmF4ngSUvjXxQUQlQiZ5lfw+w==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "escape-string-regexp": "^2.0.0",
         "lodash.deburr": "^4.1.0"
@@ -4371,7 +4424,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -4379,61 +4432,61 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@socket.io/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
       "integrity": "sha512-dOlCBKnDw4iShaIsH/bxujKTM18+2TOAsYz+KSc11Am38H4q5Xw8Bbz97ZYdrVNM+um3p7w86Bvvmcn9q+5+eQ==",
-      "dev": true
+      "devOptional": true
     },
     "@socket.io/component-emitter": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.0.0.tgz",
       "integrity": "sha512-2pTGuibAXJswAPJjaKisthqS/NOK5ypG4LYT6tEAV0S/mxW0zOIvYvGK0V8w8+SHxAm6vRMSjqSalFXeBAqs+Q==",
-      "dev": true
+      "devOptional": true
     },
     "@types/component-emitter": {
       "version": "1.2.11",
       "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
       "integrity": "sha512-SRXjM+tfsSlA9VuG8hGO2nft2p8zjXCK1VcC6N4NXbBbYbSia9kzCChYQajIjzIqOOOuh5Ock6MmV2oux4jDZQ==",
-      "dev": true
+      "devOptional": true
     },
     "@types/cookie": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
       "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
-      "dev": true
+      "devOptional": true
     },
     "@types/cors": {
       "version": "2.8.12",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
       "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
-      "dev": true
+      "devOptional": true
     },
     "@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
-      "dev": true
+      "devOptional": true
     },
     "@types/node": {
       "version": "17.0.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
       "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
-      "dev": true
+      "devOptional": true
     },
     "a-sync-waterfall": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
       "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==",
-      "dev": true
+      "devOptional": true
     },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
+      "devOptional": true
     },
     "accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
       "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
@@ -4443,19 +4496,19 @@
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "dev": true
+      "devOptional": true
     },
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true
+      "devOptional": true
     },
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -4464,7 +4517,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
       "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -4474,7 +4527,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -4483,55 +4536,55 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
       "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
-      "dev": true
+      "devOptional": true
     },
     "array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true
+      "devOptional": true
     },
     "array-uniq": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-      "dev": true
+      "devOptional": true
     },
     "arrify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
       "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-      "dev": true
+      "devOptional": true
     },
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-      "dev": true
+      "devOptional": true
     },
     "assert-never": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
       "integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==",
-      "dev": true
+      "devOptional": true
     },
     "async": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
       "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
-      "dev": true
+      "devOptional": true
     },
     "async-each-series": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
       "integrity": "sha1-dhfBkXQB/Yykooqtzj266Yr+tDI=",
-      "dev": true
+      "devOptional": true
     },
     "axios": {
       "version": "0.21.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
       "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "follow-redirects": "^1.14.0"
       }
@@ -4540,7 +4593,7 @@
       "version": "3.0.0-canary-5",
       "resolved": "https://registry.npmjs.org/babel-walk/-/babel-walk-3.0.0-canary-5.tgz",
       "integrity": "sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/types": "^7.9.6"
       }
@@ -4549,25 +4602,25 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
       "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
-      "dev": true
+      "devOptional": true
     },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "devOptional": true
     },
     "base64id": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
       "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
-      "dev": true
+      "devOptional": true
     },
     "batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
-      "dev": true
+      "devOptional": true
     },
     "bcp-47": {
       "version": "1.0.8",
@@ -4584,7 +4637,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "dev": true
+      "devOptional": true
     },
     "boolbase": {
       "version": "1.0.0",
@@ -4596,7 +4649,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4606,7 +4659,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "fill-range": "^7.0.1"
       }
@@ -4615,7 +4668,7 @@
       "version": "2.27.9",
       "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.27.9.tgz",
       "integrity": "sha512-3zBtggcaZIeU9so4ja9yxk7/CZu9B3DOL6zkxFpzHCHsQmkGBPVXg61jItbeoa+WXgNLnr1sYES/2yQwyEZ2+w==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "browser-sync-client": "^2.27.9",
         "browser-sync-ui": "^2.27.9",
@@ -4653,7 +4706,7 @@
       "version": "2.27.9",
       "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.27.9.tgz",
       "integrity": "sha512-FHW8kydp7FXo6jnX3gXJCpHAHtWNLK0nx839nnK+boMfMI1n4KZd0+DmTxHBsHsF3OHud4V4jwoN8U5HExMIdQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "etag": "1.8.1",
         "fresh": "0.5.2",
@@ -4665,7 +4718,7 @@
       "version": "2.27.9",
       "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.27.9.tgz",
       "integrity": "sha512-rsduR2bRIwFvM8CX6iY/Nu5aWub0WB9zfSYg9Le/RV5N5DEyxJYey0VxdfWCnzDOoelassTDzYQo+r0iJno3qw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "async-each-series": "0.1.1",
         "connect-history-api-fallback": "^1",
@@ -4679,25 +4732,25 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/bs-recipes/-/bs-recipes-1.3.4.tgz",
       "integrity": "sha1-DS1NSKcYyMBEdp/cT4lZLci2lYU=",
-      "dev": true
+      "devOptional": true
     },
     "bs-snippet-injector": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/bs-snippet-injector/-/bs-snippet-injector-2.0.1.tgz",
       "integrity": "sha1-YbU5PxH1JVntEgaTEANDtu2wTdU=",
-      "dev": true
+      "devOptional": true
     },
     "bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "dev": true
+      "devOptional": true
     },
     "call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -4707,7 +4760,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -4718,7 +4771,7 @@
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
           "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -4726,7 +4779,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
       "integrity": "sha1-x84o821LzZdE5f/CxfzeHHMmH8A=",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "is-regex": "^1.0.3"
       }
@@ -4735,7 +4788,7 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -4751,7 +4804,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -4762,7 +4815,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -4771,31 +4824,31 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "devOptional": true
     },
     "commander": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
       "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-      "dev": true
+      "devOptional": true
     },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
-      "dev": true
+      "devOptional": true
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "devOptional": true
     },
     "condense-newlines": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/condense-newlines/-/condense-newlines-0.2.1.tgz",
       "integrity": "sha1-PemFVTE5R10yUCyDsC9gaE0kxV8=",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "extend-shallow": "^2.0.1",
         "is-whitespace": "^0.3.0",
@@ -4806,7 +4859,7 @@
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -4817,7 +4870,7 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
       "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "ini": "^1.3.4",
         "proto-list": "~1.2.1"
@@ -4827,7 +4880,7 @@
       "version": "3.6.6",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
       "integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "debug": "2.6.9",
         "finalhandler": "1.1.0",
@@ -4839,7 +4892,7 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -4848,7 +4901,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -4856,13 +4909,13 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
       "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
-      "dev": true
+      "devOptional": true
     },
     "constantinople": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
       "integrity": "sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/parser": "^7.6.0",
         "@babel/types": "^7.6.1"
@@ -4872,13 +4925,13 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
       "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-      "dev": true
+      "devOptional": true
     },
     "cors": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
       "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "object-assign": "^4",
         "vary": "^1"
@@ -4923,7 +4976,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -4932,13 +4985,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "dev": true
+      "devOptional": true
     },
     "dependency-graph": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
       "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
-      "dev": true
+      "devOptional": true
     },
     "dequal": {
       "version": "2.0.2",
@@ -4950,13 +5003,13 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-      "dev": true
+      "devOptional": true
     },
     "dev-ip": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz",
       "integrity": "sha1-p2o+0YVb56ASu4rBbLgPPADcKPA=",
-      "dev": true
+      "devOptional": true
     },
     "diff": {
       "version": "5.0.0",
@@ -4968,19 +5021,18 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true
+      "devOptional": true
     },
     "doctypes": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
       "integrity": "sha1-6oCxBqh1OHdOijpKWv4pPeSJ4Kk=",
-      "dev": true
+      "devOptional": true
     },
     "dom-serializer": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
       "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
-      "dev": true,
       "requires": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.2.0",
@@ -4990,14 +5042,12 @@
     "domelementtype": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
-      "dev": true
+      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
     },
     "domhandler": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
       "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-      "dev": true,
       "requires": {
         "domelementtype": "^2.2.0"
       }
@@ -5006,7 +5056,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
       "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-      "dev": true,
       "requires": {
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",
@@ -5017,7 +5066,7 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.4.tgz",
       "integrity": "sha512-8cAwm6md1YTiPpOvDULYJL4ZS6WfM5/cTeVVh4JsvyYZAoqlRVUpHL9Gr5Fy7HA6xcSZicUia3DeAgO3Us8E+Q==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "lodash": "^4.17.10"
       }
@@ -5026,7 +5075,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-3.1.0.tgz",
       "integrity": "sha512-/snsn2JqBtUSSstEl4R0RKjkisGHAhvYj89i7r3ytNUKW12y178KDZwXLXIgwDqLW6E/VRMT9qfld7wvFae8bQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "tfunk": "^4.0.0"
       }
@@ -5035,7 +5084,7 @@
       "version": "0.15.3",
       "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
       "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "commander": "^2.19.0",
         "lru-cache": "^4.1.5",
@@ -5047,13 +5096,13 @@
           "version": "2.20.3",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
           "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true
+          "devOptional": true
         },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -5061,34 +5110,42 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-      "dev": true
+      "devOptional": true
     },
     "ejs": {
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.6.tgz",
       "integrity": "sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "jake": "^10.6.1"
+      }
+    },
+    "eleventy-plugin-automatic-noopener": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eleventy-plugin-automatic-noopener/-/eleventy-plugin-automatic-noopener-2.0.2.tgz",
+      "integrity": "sha512-uMHHAG7SUwiuNTd1yPTe8ijIjyTghV9JVXJ/vOUdbu+r3O0aJJ3ARsKAz83GMdSFivrY4XOnenlCOXeovGNBQw==",
+      "requires": {
+        "posthtml": "^0.16.0"
       }
     },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "devOptional": true
     },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-      "dev": true
+      "devOptional": true
     },
     "engine.io": {
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.1.3.tgz",
       "integrity": "sha512-rqs60YwkvWTLLnfazqgZqLa/aKo+9cueVfEi/dZ8PyGyaf8TLOxj++4QMIgeG3Gn0AhrWiFXvghsoY9L9h25GA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@types/cookie": "^0.4.1",
         "@types/cors": "^2.8.12",
@@ -5106,7 +5163,7 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.1.1.tgz",
       "integrity": "sha512-V05mmDo4gjimYW+FGujoGmmmxRaDsrVr7AXA3ZIfa04MWM1jOfZfUwou0oNqhNwy/votUDvGDt4JA4QF4e0b4g==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@socket.io/component-emitter": "~3.0.0",
         "debug": "~4.3.1",
@@ -5123,7 +5180,7 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.3.tgz",
       "integrity": "sha512-BtQxwF27XUNnSafQLvDi0dQ8s3i6VgzSoQMJacpIcGNrlUdfHSKbgm3jmjCVvQluGzqwujQMPAoMai3oYSTurg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@socket.io/base64-arraybuffer": "~1.0.2"
       }
@@ -5131,14 +5188,13 @@
     "entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
-      "dev": true
+      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
     },
     "errno": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
       "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "prr": "~1.0.1"
       }
@@ -5315,43 +5371,43 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true
+      "devOptional": true
     },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-      "dev": true
+      "devOptional": true
     },
     "escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true
+      "devOptional": true
     },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "devOptional": true
     },
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-      "dev": true
+      "devOptional": true
     },
     "eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true
+      "devOptional": true
     },
     "extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "is-extendable": "^0.1.0"
       }
@@ -5360,7 +5416,7 @@
       "version": "3.2.11",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
       "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -5373,7 +5429,7 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
       "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "reusify": "^1.0.4"
       }
@@ -5382,7 +5438,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.2.tgz",
       "integrity": "sha512-z7O0IS8Plc39rTCq6i6iHxk43duYOn8uFJiWSewIq0Bww1RNybVHSCjahmcC87ZqAm4OTvFzlzeGu3XAzG1ctQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "minimatch": "^3.0.4"
       }
@@ -5391,7 +5447,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -5400,7 +5456,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
       "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.1",
@@ -5415,7 +5471,7 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -5424,7 +5480,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -5432,19 +5488,19 @@
       "version": "1.14.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
       "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
-      "dev": true
+      "devOptional": true
     },
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-      "dev": true
+      "devOptional": true
     },
     "fs-extra": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
       "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^3.0.0",
@@ -5455,7 +5511,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "devOptional": true
     },
     "fsevents": {
       "version": "2.3.2",
@@ -5468,19 +5524,19 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "devOptional": true
     },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
+      "devOptional": true
     },
     "get-intrinsic": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
       "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -5491,7 +5547,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -5505,7 +5561,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -5514,13 +5570,13 @@
       "version": "4.2.9",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
       "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
-      "dev": true
+      "devOptional": true
     },
     "gray-matter": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
       "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "js-yaml": "^3.13.1",
         "kind-of": "^6.0.2",
@@ -5532,13 +5588,13 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/hamljs/-/hamljs-0.6.2.tgz",
       "integrity": "sha1-e3EWz22+cnjkKz9u+HJaM+F3yOM=",
-      "dev": true
+      "devOptional": true
     },
     "handlebars": {
       "version": "4.7.7",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
       "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
@@ -5551,7 +5607,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -5560,7 +5616,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       },
@@ -5569,7 +5625,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -5577,33 +5633,33 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
       "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
-      "dev": true
+      "devOptional": true
     },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "devOptional": true
     },
     "has-symbols": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true
+      "devOptional": true
     },
     "has-tostringtag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
       "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "has-symbols": "^1.0.2"
       }
     },
     "hdot": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/hdot/-/hdot-0.0.2.tgz",
-      "integrity": "sha512-1jYEmSuvUXIsZUspILm5BYmRII+dOwmvM+QYmq6AiN6F6mYp72jNlLImoIgq5IIJcz5RYwvzbxXFaYC+GjgCzw==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/hdot/-/hdot-0.0.7.tgz",
+      "integrity": "sha512-gCSpxQdh9GhpVSPwWLyKt7Ok4941tyXYPmp11hJ32tEYABbBuQNQ1n5FKKTRbAmngyDPS8yBUdNeht09pp/gqw==",
       "dev": true
     },
     "html-escaper": {
@@ -5616,7 +5672,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
       "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
-      "dev": true,
       "requires": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.2.2",
@@ -5627,8 +5682,7 @@
         "entities": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-          "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
-          "dev": true
+          "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="
         }
       }
     },
@@ -5636,7 +5690,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
       "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "depd": "2.0.0",
         "inherits": "2.0.4",
@@ -5649,7 +5703,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
           "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -5657,7 +5711,7 @@
       "version": "1.18.1",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
       "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
@@ -5668,7 +5722,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -5677,13 +5731,13 @@
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
       "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=",
-      "dev": true
+      "devOptional": true
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -5693,13 +5747,13 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "devOptional": true
     },
     "ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true
+      "devOptional": true
     },
     "is-alphabetical": {
       "version": "1.0.4",
@@ -5721,7 +5775,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "binary-extensions": "^2.0.0"
       }
@@ -5730,13 +5784,13 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "devOptional": true
     },
     "is-core-module": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
       "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "has": "^1.0.3"
       }
@@ -5751,7 +5805,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
       "integrity": "sha512-zMIXX63sxzG3XrkHkrAPvm/OVZVSCPNkwMHU8oTX7/U3AL78I0QXCEICXUM13BIa8TYGZ68PiTKfQz3yaTNr4A==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "acorn": "^7.1.1",
         "object-assign": "^4.1.1"
@@ -5761,40 +5815,45 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "dev": true
+      "devOptional": true
     },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
+      "devOptional": true
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true
+      "devOptional": true
     },
     "is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
+    },
+    "is-json": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-json/-/is-json-2.0.1.tgz",
+      "integrity": "sha1-a+Fm0USCihMdaGiRuYPfYsOUkf8="
     },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true
+      "devOptional": true
     },
     "is-number-like": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz",
       "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "lodash.isfinite": "^3.3.2"
       }
@@ -5803,13 +5862,13 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
-      "dev": true
+      "devOptional": true
     },
     "is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
       "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -5819,19 +5878,19 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/is-whitespace/-/is-whitespace-0.3.0.tgz",
       "integrity": "sha1-Fjnssb4DauxppUy7QBz77XEUq38=",
-      "dev": true
+      "devOptional": true
     },
     "is-wsl": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
       "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-      "dev": true
+      "devOptional": true
     },
     "jake": {
       "version": "10.8.2",
       "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.2.tgz",
       "integrity": "sha512-eLpKyrfG3mzvGE2Du8VoPbeSkRry093+tyNjdYaBbJS9v17knImYGNXQCUV0gLxQtF82m3E8iRb/wdSQZLoq7A==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "async": "0.9.x",
         "chalk": "^2.4.2",
@@ -5843,7 +5902,7 @@
       "version": "1.14.0",
       "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.0.tgz",
       "integrity": "sha512-yuck9KirNSCAwyNJbqW+BxJqJ0NLJ4PwBUzQQACl5O3qHMBXVkXb/rD0ilh/Lat/tn88zSZ+CAHOlk0DsY7GuQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "config-chain": "^1.1.12",
         "editorconfig": "^0.15.3",
@@ -5855,13 +5914,13 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
       "integrity": "sha1-Fzb939lyTyijaCrcYjCufk6Weds=",
-      "dev": true
+      "devOptional": true
     },
     "js-yaml": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -5871,7 +5930,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
       "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -5880,7 +5939,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-1.0.0.tgz",
       "integrity": "sha1-7Yvwkh4vPx7U1cGkT2hwntJHIsM=",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "is-promise": "^2.0.0",
         "promise": "^7.0.1"
@@ -5890,19 +5949,19 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/junk/-/junk-1.0.3.tgz",
       "integrity": "sha1-h75jSIZJy9ym9Tqzm+yczSNH9ZI=",
-      "dev": true
+      "devOptional": true
     },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "dev": true
+      "devOptional": true
     },
     "kleur": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
       "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
-      "dev": true
+      "devOptional": true
     },
     "leven": {
       "version": "3.1.0",
@@ -5914,7 +5973,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
       "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==",
-      "dev": true
+      "devOptional": true
     },
     "linkedom": {
       "version": "0.13.7",
@@ -5933,7 +5992,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
       "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "uc.micro": "^1.0.1"
       }
@@ -5942,13 +6001,13 @@
       "version": "9.36.0",
       "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-9.36.0.tgz",
       "integrity": "sha512-HbU4xBsY1r3ZEORTgPsiluXsOtMx8iI0MqTsPejgIk+sIgta5wQUYsoQgUPuGKWVHKKKMO9PidiMEPKlePl8rg==",
-      "dev": true
+      "devOptional": true
     },
     "localtunnel": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-2.0.2.tgz",
       "integrity": "sha512-n418Cn5ynvJd7m/N1d9WVJISLJF/ellZnfsLnx8WBWGzxv/ntNcFkJ1o6se5quUhCplfLGBNL5tYHiq5WF3Nug==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "axios": "0.21.4",
         "debug": "4.3.2",
@@ -5960,7 +6019,7 @@
           "version": "4.3.2",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
           "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "ms": "2.1.2"
           }
@@ -5969,7 +6028,7 @@
           "version": "17.1.1",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.1.tgz",
           "integrity": "sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "cliui": "^7.0.2",
             "escalade": "^3.1.1",
@@ -5984,7 +6043,7 @@
           "version": "20.2.9",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
           "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -5992,25 +6051,25 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "devOptional": true
     },
     "lodash.deburr": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-4.1.0.tgz",
       "integrity": "sha1-3bG7s+8HRYwBd7oH3hRCLLAz/5s=",
-      "dev": true
+      "devOptional": true
     },
     "lodash.isfinite": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
       "integrity": "sha1-+4m2WpqAKBgz8LdHizpRBPiY67M=",
-      "dev": true
+      "devOptional": true
     },
     "lru-cache": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
       "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
@@ -6020,13 +6079,13 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.3.1.tgz",
       "integrity": "sha512-I8vnjOmhXsMSlNMZlMkSOvgrxKJl0uOsEzdGgGNZuZPaS9KlefpE9KV95QFftlJSC+1UyCC9/I69R02cz/zcCA==",
-      "dev": true
+      "devOptional": true
     },
     "markdown-it": {
       "version": "12.3.2",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
       "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "argparse": "^2.0.1",
         "entities": "~2.1.0",
@@ -6039,7 +6098,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -6047,7 +6106,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/maximatch/-/maximatch-0.1.0.tgz",
       "integrity": "sha1-hs2NawTJ8wfAWmuUGZBtA2D7E6I=",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "array-differ": "^1.0.0",
         "array-union": "^1.0.1",
@@ -6059,13 +6118,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
           "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
-          "dev": true
+          "devOptional": true
         },
         "array-union": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
           "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "array-uniq": "^1.0.1"
           }
@@ -6074,7 +6133,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
           "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -6088,19 +6147,19 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
       "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
-      "dev": true
+      "devOptional": true
     },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true
+      "devOptional": true
     },
     "micromatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
       "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "braces": "^3.0.1",
         "picomatch": "^2.2.3"
@@ -6110,19 +6169,19 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
       "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
-      "dev": true
+      "devOptional": true
     },
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true
+      "devOptional": true
     },
     "mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "mime-db": "1.52.0"
       }
@@ -6131,7 +6190,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -6140,19 +6199,19 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "devOptional": true
     },
     "mitt": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.2.0.tgz",
       "integrity": "sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw==",
-      "dev": true
+      "devOptional": true
     },
     "mkdirp": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "minimist": "^1.2.5"
       }
@@ -6161,7 +6220,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
       "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==",
-      "dev": true
+      "devOptional": true
     },
     "mri": {
       "version": "1.2.0",
@@ -6173,13 +6232,13 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "devOptional": true
     },
     "multimatch": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-5.0.0.tgz",
       "integrity": "sha512-ypMKuglUrZUD99Tk2bUQ+xNQj43lPEfAeX2o9cTteAmShXy2VHDJpuwu1o0xqoKCt9jLVAvwyFKdLTPXKAfJyA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@types/minimatch": "^3.0.3",
         "array-differ": "^3.0.0",
@@ -6192,25 +6251,25 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
       "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
-      "dev": true
+      "devOptional": true
     },
     "negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-      "dev": true
+      "devOptional": true
     },
     "neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true
+      "devOptional": true
     },
     "nopt": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
       "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "abbrev": "1"
       }
@@ -6219,7 +6278,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true
+      "devOptional": true
     },
     "nth-check": {
       "version": "2.0.1",
@@ -6234,7 +6293,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.3.tgz",
       "integrity": "sha512-psb6xjLj47+fE76JdZwskvwG4MYsQKXUtMsPh6U0YMvmyjRtKRFcxnlXGWglNybtNTNVmGdp94K62/+NjF5FDQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "a-sync-waterfall": "^1.0.0",
         "asap": "^2.0.3",
@@ -6245,13 +6304,13 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "devOptional": true
     },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "ee-first": "1.1.1"
       }
@@ -6260,7 +6319,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "wrappy": "1"
       }
@@ -6269,13 +6328,13 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz",
       "integrity": "sha1-OHW0sO96UsFW8NtB1GCduw+Us4c=",
-      "dev": true
+      "devOptional": true
     },
     "opn": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
       "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "is-wsl": "^1.1.0"
       }
@@ -6284,55 +6343,55 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
       "integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w==",
-      "dev": true
+      "devOptional": true
     },
     "parseuri": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
       "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow==",
-      "dev": true
+      "devOptional": true
     },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "dev": true
+      "devOptional": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "devOptional": true
     },
     "path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "devOptional": true
     },
     "path-to-regexp": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz",
       "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg==",
-      "dev": true
+      "devOptional": true
     },
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true
+      "devOptional": true
     },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-      "dev": true
+      "devOptional": true
     },
     "please-upgrade-node": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
       "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "semver-compare": "^1.0.0"
       }
@@ -6341,7 +6400,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.1.1.tgz",
       "integrity": "sha1-6rtAnk3iSVD1oqUW01rnaTQ/u5Y=",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "async": "1.5.2",
         "is-number-like": "^1.0.3"
@@ -6351,15 +6410,40 @@
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
+          "devOptional": true
         }
+      }
+    },
+    "posthtml": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.6.tgz",
+      "integrity": "sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==",
+      "requires": {
+        "posthtml-parser": "^0.11.0",
+        "posthtml-render": "^3.0.0"
+      }
+    },
+    "posthtml-parser": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.11.0.tgz",
+      "integrity": "sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==",
+      "requires": {
+        "htmlparser2": "^7.1.1"
+      }
+    },
+    "posthtml-render": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
+      "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
+      "requires": {
+        "is-json": "^2.0.1"
       }
     },
     "pretty": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pretty/-/pretty-2.0.0.tgz",
       "integrity": "sha1-rbx5YLe7/iiaVX3F9zdhmiINBqU=",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "condense-newlines": "^0.2.1",
         "extend-shallow": "^2.0.1",
@@ -6376,7 +6460,7 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "asap": "~2.0.3"
       }
@@ -6385,25 +6469,25 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
-      "dev": true
+      "devOptional": true
     },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-      "dev": true
+      "devOptional": true
     },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
+      "devOptional": true
     },
     "pug": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/pug/-/pug-3.0.2.tgz",
       "integrity": "sha512-bp0I/hiK1D1vChHh6EfDxtndHji55XP/ZJKwsRqrz6lRia6ZC2OZbdAymlxdVFwd1L70ebrVJw4/eZ79skrIaw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "pug-code-gen": "^3.0.2",
         "pug-filters": "^4.0.0",
@@ -6419,7 +6503,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-3.0.0.tgz",
       "integrity": "sha512-azINV9dUtzPMFQktvTXciNAfAuVh/L/JCl0vtPCwvOA21uZrC08K/UnmrL+SXGEVc1FwzjW62+xw5S/uaLj6cA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "constantinople": "^4.0.1",
         "js-stringify": "^1.0.2",
@@ -6430,7 +6514,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.2.tgz",
       "integrity": "sha512-nJMhW16MbiGRiyR4miDTQMRWDgKplnHyeLvioEJYbk1RsPI3FuA3saEP8uwnTb2nTJEKBU90NFVWJBk4OU5qyg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "constantinople": "^4.0.1",
         "doctypes": "^1.1.0",
@@ -6446,13 +6530,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-2.0.0.tgz",
       "integrity": "sha512-sjiUsi9M4RAGHktC1drQfCr5C5eriu24Lfbt4s+7SykztEOwVZtbFk1RRq0tzLxcMxMYTBR+zMQaG07J/btayQ==",
-      "dev": true
+      "devOptional": true
     },
     "pug-filters": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
       "integrity": "sha512-yeNFtq5Yxmfz0f9z2rMXGw/8/4i1cCFecw/Q7+D0V2DdtII5UvqE12VaZ2AY7ri6o5RNXiweGH79OCq+2RQU4A==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "constantinople": "^4.0.1",
         "jstransformer": "1.0.0",
@@ -6465,7 +6549,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-5.0.1.tgz",
       "integrity": "sha512-0I6C62+keXlZPZkOJeVam9aBLVP2EnbeDw3An+k0/QlqdwH6rv8284nko14Na7c0TtqtogfWXcRoFE4O4Ff20w==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "character-parser": "^2.2.0",
         "is-expression": "^4.0.0",
@@ -6476,7 +6560,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
       "integrity": "sha512-gjD1yzp0yxbQqnzBAdlhbgoJL5qIFJw78juN1NpTLt/mfPJ5VgC4BvkoD3G23qKzJtIIXBbcCt6FioLSFLOHdw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "pug-error": "^2.0.0",
         "pug-walk": "^2.0.0"
@@ -6486,7 +6570,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pug-load/-/pug-load-3.0.0.tgz",
       "integrity": "sha512-OCjTEnhLWZBvS4zni/WUMjH2YSUosnsmjGBB1An7CsKQarYSWQ0GCVyd4eQPMFJqZ8w9xgs01QdiZXKVjk92EQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "object-assign": "^4.1.1",
         "pug-walk": "^2.0.0"
@@ -6496,7 +6580,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
       "integrity": "sha512-ukiYM/9cH6Cml+AOl5kETtM9NR3WulyVP2y4HOU45DyMim1IeP/OOiyEWRr6qk5I5klpsBnbuHpwKmTx6WURnw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "pug-error": "^2.0.0",
         "token-stream": "1.0.0"
@@ -6506,13 +6590,13 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-3.0.1.tgz",
       "integrity": "sha512-L50zbvrQ35TkpHwv0G6aLSuueDRwc/97XdY8kL3tOT0FmhgG7UypU3VztfV/LATAvmUfYi4wNxSajhSAeNN+Kg==",
-      "dev": true
+      "devOptional": true
     },
     "pug-strip-comments": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
       "integrity": "sha512-zo8DsDpH7eTkPHCXFeAk1xZXJbyoTfdPlNR0bK7rpOMuhBYb0f5qUVCO1xlsitYd3w5FQTK7zpNVKb3rZoUrrQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "pug-error": "^2.0.0"
       }
@@ -6521,31 +6605,31 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-2.0.0.tgz",
       "integrity": "sha512-yYELe9Q5q9IQhuvqsZNwA5hfPkMJ8u92bQLIMcsMxf/VADjNtEYptU+inlufAFYcWdHlwNfZOEnOOQrZrcyJCQ==",
-      "dev": true
+      "devOptional": true
     },
     "qs": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
       "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4=",
-      "dev": true
+      "devOptional": true
     },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true
+      "devOptional": true
     },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-      "dev": true
+      "devOptional": true
     },
     "raw-body": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
       "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
@@ -6557,7 +6641,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "picomatch": "^2.2.1"
       }
@@ -6566,7 +6650,7 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/recursive-copy/-/recursive-copy-2.0.14.tgz",
       "integrity": "sha512-K8WNY8f8naTpfbA+RaXmkaQuD1IeW9EgNEfyGxSqqTQukpVtoOKros9jUqbpEsSw59YOmpd8nCBgtqJZy5nvog==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "errno": "^0.1.2",
         "graceful-fs": "^4.1.4",
@@ -6583,19 +6667,19 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "devOptional": true
     },
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-      "dev": true
+      "devOptional": true
     },
     "resolve": {
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
       "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "is-core-module": "^2.8.1",
         "path-parse": "^1.0.7",
@@ -6606,7 +6690,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.2.tgz",
       "integrity": "sha1-sSTeXE+6/LpUH0j/pzlw9KpFa08=",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "debug": "^2.2.0",
         "minimatch": "^3.0.2"
@@ -6616,7 +6700,7 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -6625,7 +6709,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -6633,13 +6717,13 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true
+      "devOptional": true
     },
     "rimraf": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -6648,7 +6732,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "queue-microtask": "^1.2.2"
       }
@@ -6657,13 +6741,13 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
       "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
-      "dev": true
+      "devOptional": true
     },
     "rxjs": {
       "version": "5.5.12",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
       "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "symbol-observable": "1.0.1"
       }
@@ -6681,13 +6765,13 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "devOptional": true
     },
     "section-matter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
       "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "extend-shallow": "^2.0.1",
         "kind-of": "^6.0.0"
@@ -6697,7 +6781,7 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "lru-cache": "^6.0.0"
       },
@@ -6706,7 +6790,7 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -6715,7 +6799,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -6723,13 +6807,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
-      "dev": true
+      "devOptional": true
     },
     "send": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
       "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "debug": "2.6.9",
         "depd": "~1.1.2",
@@ -6750,7 +6834,7 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -6759,13 +6843,13 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
           "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-          "dev": true
+          "devOptional": true
         },
         "http-errors": {
           "version": "1.6.3",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "depd": "~1.1.2",
             "inherits": "2.0.3",
@@ -6777,25 +6861,25 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "devOptional": true
         },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
+          "devOptional": true
         },
         "setprototypeof": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
           "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-          "dev": true
+          "devOptional": true
         },
         "statuses": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
           "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -6803,7 +6887,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "accepts": "~1.3.4",
         "batch": "0.6.1",
@@ -6818,7 +6902,7 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -6827,13 +6911,13 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
           "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-          "dev": true
+          "devOptional": true
         },
         "http-errors": {
           "version": "1.6.3",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "depd": "~1.1.2",
             "inherits": "2.0.3",
@@ -6845,25 +6929,25 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "devOptional": true
         },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
+          "devOptional": true
         },
         "setprototypeof": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
           "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-          "dev": true
+          "devOptional": true
         },
         "statuses": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
           "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -6871,7 +6955,7 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
@@ -6883,37 +6967,37 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
       "integrity": "sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0=",
-      "dev": true
+      "devOptional": true
     },
     "setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "dev": true
+      "devOptional": true
     },
     "sigmund": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
       "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-      "dev": true
+      "devOptional": true
     },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-      "dev": true
+      "devOptional": true
     },
     "slugify": {
       "version": "1.6.5",
       "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.5.tgz",
       "integrity": "sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ==",
-      "dev": true
+      "devOptional": true
     },
     "socket.io": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.4.1.tgz",
       "integrity": "sha512-s04vrBswdQBUmuWJuuNTmXUVJhP0cVky8bBDhdkf8y0Ptsu7fKU2LuLbts9g+pdmAdyMMn8F/9Mf1/wbtUN0fg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
@@ -6927,13 +7011,13 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.3.3.tgz",
       "integrity": "sha512-Qd/iwn3VskrpNO60BeRyCyr8ZWw9CPZyitW4AQwmRZ8zCiyDiL+znRnWX6tDHXnWn1sJrM1+b6Mn6wEDJJ4aYQ==",
-      "dev": true
+      "devOptional": true
     },
     "socket.io-client": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.4.1.tgz",
       "integrity": "sha512-N5C/L5fLNha5Ojd7Yeb/puKcPWWcoB/A09fEjjNsg91EDVr5twk/OEyO6VT9dlLSUNY85NpW6KBhVMvaLKQ3vQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@socket.io/component-emitter": "~3.0.0",
         "backo2": "~1.0.2",
@@ -6947,7 +7031,7 @@
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.1.2.tgz",
           "integrity": "sha512-j3kk71QLJuyQ/hh5F/L2t1goqzdTL0gvDzuhTuNSwihfuFUrcSji0qFZmJJPtG6Rmug153eOPsUizeirf1IIog==",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "@socket.io/component-emitter": "~3.0.0",
             "debug": "~4.3.1"
@@ -6959,7 +7043,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.4.tgz",
       "integrity": "sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@types/component-emitter": "^1.2.10",
         "component-emitter": "~1.3.0",
@@ -6970,25 +7054,25 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
+      "devOptional": true
     },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "devOptional": true
     },
     "statuses": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
-      "dev": true
+      "devOptional": true
     },
     "stream-throttle": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
       "integrity": "sha1-rdV8jXzHOoFjDTHNVdOWHPr7qcM=",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "commander": "^2.2.0",
         "limiter": "^1.0.5"
@@ -6998,7 +7082,7 @@
           "version": "2.20.3",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
           "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -7006,7 +7090,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -7017,7 +7101,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }
@@ -7026,13 +7110,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
       "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI=",
-      "dev": true
+      "devOptional": true
     },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -7041,19 +7125,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true
+      "devOptional": true
     },
     "symbol-observable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
       "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
-      "dev": true
+      "devOptional": true
     },
     "tfunk": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/tfunk/-/tfunk-4.0.0.tgz",
       "integrity": "sha512-eJQ0dGfDIzWNiFNYFVjJ+Ezl/GmwHaFTBTjrtqNPW0S7cuVDBrZrmzUz6VkMeCR4DZFqhd4YtLwsw3i2wYHswQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "chalk": "^1.1.3",
         "dlv": "^1.1.3"
@@ -7063,19 +7147,19 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "devOptional": true
         },
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
+          "devOptional": true
         },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -7088,13 +7172,13 @@
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
           "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
+          "devOptional": true
         },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7103,7 +7187,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -7111,13 +7195,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true
+      "devOptional": true
     },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "is-number": "^7.0.0"
       }
@@ -7126,13 +7210,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "dev": true
+      "devOptional": true
     },
     "token-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
       "integrity": "sha1-zCAOqyYT9BZtJ/+a/HylbUnfbrQ=",
-      "dev": true
+      "devOptional": true
     },
     "tslib": {
       "version": "2.3.1",
@@ -7153,13 +7237,13 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.2.tgz",
       "integrity": "sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg==",
-      "dev": true
+      "devOptional": true
     },
     "uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
-      "dev": true
+      "devOptional": true
     },
     "uglify-js": {
       "version": "3.15.3",
@@ -7178,19 +7262,19 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true
+      "devOptional": true
     },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-      "dev": true
+      "devOptional": true
     },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
-      "dev": true
+      "devOptional": true
     },
     "uvu": {
       "version": "0.5.3",
@@ -7208,13 +7292,13 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-      "dev": true
+      "devOptional": true
     },
     "void-elements": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
       "integrity": "sha1-YU9/v42AHwu18GYfWy9XhXUOTwk=",
-      "dev": true
+      "devOptional": true
     },
     "whatwg-mimetype": {
       "version": "2.3.0",
@@ -7226,7 +7310,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/with/-/with-7.0.2.tgz",
       "integrity": "sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/parser": "^7.9.6",
         "@babel/types": "^7.9.6",
@@ -7238,13 +7322,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-      "dev": true
+      "devOptional": true
     },
     "wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -7255,7 +7339,7 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -7264,7 +7348,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -7273,7 +7357,7 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -7281,38 +7365,38 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "devOptional": true
     },
     "ws": {
       "version": "8.2.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
       "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {}
     },
     "xmlhttprequest-ssl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
       "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
-      "dev": true
+      "devOptional": true
     },
     "y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true
+      "devOptional": true
     },
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-      "dev": true
+      "devOptional": true
     },
     "yargs": {
       "version": "17.3.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
       "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -7327,13 +7411,13 @@
       "version": "21.0.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
       "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
-      "dev": true
+      "devOptional": true
     },
     "yeast": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
-      "dev": true
+      "devOptional": true
     }
   }
 }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@11ty/eleventy": "^1.0.0",
+    "eleventy-plugin-automatic-noopener": "^2.0.2",
     "@11ty/eleventy-plugin-syntaxhighlight": "^4.0.0",
     "@hdot/validate": "^0.0.7",
     "hdot": "^0.0.7",

--- a/packages/hdot/CHANGELOG.md
+++ b/packages/hdot/CHANGELOG.md
@@ -5,18 +5,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [0.0.7](https://github.com/willmartian/hdot/compare/hdot@0.0.6...hdot@0.0.7) (2022-03-29)
 
-
 ### Bug Fixes
 
-* **hdot:** call return type is now string ([#8](https://github.com/willmartian/hdot/issues/8)) ([f6907b4](https://github.com/willmartian/hdot/commit/f6907b420bcc19f20cba4cd9959c6bf9e07cdad8))
-
-
-
-
+- **hdot:** call return type is now string ([#8](https://github.com/willmartian/hdot/issues/8)) ([f6907b4](https://github.com/willmartian/hdot/commit/f6907b420bcc19f20cba4cd9959c6bf9e07cdad8))
 
 ## [0.0.6](https://github.com/willmartian/hdot/compare/hdot@0.0.5...hdot@0.0.6) (2022-03-29)
 
-
 ### Bug Fixes
 
-* **hdot:** aria attributes now serialize properly ([#6](https://github.com/willmartian/hdot/issues/6)) ([041c297](https://github.com/willmartian/hdot/commit/041c297040bca6c505565a2c28ffef3187cb83a2))
+- **hdot:** aria attributes now serialize properly ([#6](https://github.com/willmartian/hdot/issues/6)) ([041c297](https://github.com/willmartian/hdot/commit/041c297040bca6c505565a2c28ffef3187cb83a2))

--- a/packages/hdot/src/hdot.ts
+++ b/packages/hdot/src/hdot.ts
@@ -1,66 +1,58 @@
-import { isTemplateParam, rawTemplate } from "./utils";
-import type { HTMLElements } from "./types/html";
+import {
+  fakeBaseClass,
+  isTemplateParam,
+  rawTemplate,
+  keyIsOmitted,
+} from "./utils";
+import { HTMLElements, PluginArray, TreeNode } from "./types";
+export * from "./types";
 
-export type Plugin = {
-  attribute?: (tagName: string, key: string, args: any) => [string, any];
-};
-
-class PrivateState {
-  private _plugins: Plugin[] = [];
-}
-
-export const setPlugins = (h: H, plugins: Plugin[]) => {
-  h["_plugins"] = plugins;
-};
-
-export type H = typeof PrivateState & HTMLElements;
-
-export const h: H = new Proxy(new PrivateState() as unknown as H, {
-  get(target, key, reciever) {
-    if (typeof key !== "string" || key === "toString" || key.startsWith("#")) {
-      return Reflect.get(target, key, reciever);
-    }
-    return new Hdot(key, target);
-  },
-});
-
-const getAttributeName = (rawName) => {
-  let name = rawName;
-  if (name.length > 4 && (name.startsWith("data") || name.startsWith("aria"))) {
-    name = name.slice(0, 4) + '-' + name.slice(4);
-  }
-  return name.toLowerCase();
-}
-
-class Hdot extends Function {
-  private htmlString: string = "";
-
-  constructor(tagName, h: HTMLElements) {
+export class hdot extends fakeBaseClass<HTMLElements>() {
+  constructor(plugins: PluginArray = []) {
     super();
-    this.htmlString = tagName + " ";
+
+    return new Proxy(this, {
+      get(target, key, reciever) {
+        if (keyIsOmitted(key, "toString")) {
+          return Reflect.get(target, key, reciever);
+        }
+        return new hdotElement(key, plugins);
+      },
+    }) as HTMLElements;
+  }
+}
+
+export const h = new hdot();
+
+class hdotElement extends Function {
+  private treeNode: TreeNode;
+  private defaultPlugins: PluginArray = [];
+
+  constructor(tagName: string, plugins: PluginArray = []) {
+    super();
+    this.treeNode = {
+      tag: tagName,
+      attrs: {},
+      content: [""],
+    };
+    this.defaultPlugins = plugins;
 
     const proxy = new Proxy(this, {
       get(target, key, reciever) {
         if (
-          typeof key !== "string" ||
-          key === "toString" ||
-          key === "htmlString" ||
-          key === "raw"
+          keyIsOmitted(key, "toString", "treeNode", "raw", "defaultPlugins")
         ) {
           return Reflect.get(target, key, reciever);
         }
         return (args: any) => {
-          let k = getAttributeName(key);
-
-          let a = args;
-          for (const plugin of h["_plugins"]) {
-            if (plugin.attribute) {
-              const [pluginKey, pluginArgs] = plugin.attribute(tagName, k, a);
-              k = pluginKey;
-              a = pluginArgs;
-            }
+          let name = key.toLowerCase();
+          if (
+            name.length > 4 &&
+            (name.startsWith("data") || name.startsWith("aria"))
+          ) {
+            name = name.slice(0, 4) + "-" + name.slice(4);
           }
-          target.htmlString += target.attribute(k, a);
+          target.treeNode.attrs[name] = args;
           return proxy;
         };
       },
@@ -71,31 +63,44 @@ class Hdot extends Function {
     return proxy;
   }
 
-  attribute(key: string, value: any) {
-    let attributeString = "";
-    if (typeof value === "boolean") {
-      attributeString = value ? `${key}` : "";
-    } else {
-      attributeString = `${key}${value ? `="${value}"` : ""}`;
-    }
-    return attributeString + " ";
-  }
-
-  toString(...children: any[]) {
-    let args: string | any[] = children.join("");
-    if (isTemplateParam(...children)) {
-      args = [rawTemplate(children[0], ...children.slice(1))];
-    }
-    return `<${this.htmlString.trim()}>${args}</${
-      this.htmlString.split(" ")[0]
-    }>`;
-  }
-
   #call(...children: any[]) {
     let args: string | any[] = children;
     if (isTemplateParam(...children)) {
       args = [rawTemplate(children[0], ...children.slice(1))];
     }
-    return this.toString(...children);
+    this.treeNode.content = [...args];
+    return this;
+  }
+
+  /**
+   * Converts the hdot tree to HTML.
+   * @param plugins array of hdot plugins
+   * @returns HTML string
+   */
+  toString(plugins?: PluginArray): string {
+    const _plugins = plugins !== undefined ? plugins : this.defaultPlugins;
+    let returnValue: string | TreeNode = this.treeNode;
+    _plugins.forEach((plugin) => {
+      /** @todo fix casting */
+      returnValue = plugin(returnValue as TreeNode);
+    });
+    if (typeof returnValue === "string") {
+      return returnValue;
+    }
+
+    const { tag, attrs, content } = returnValue;
+    let htmlString = `<${tag}`;
+    for (const key in attrs) {
+      const value = attrs[key];
+      let attributeString = "";
+      if (typeof value === "boolean") {
+        attributeString = value ? `${key}` : "";
+      } else {
+        attributeString = `${key}${value ? `="${value}"` : ""}`;
+      }
+      htmlString += " " + attributeString;
+    }
+    htmlString += `>${content.join("")}</${tag}>`;
+    return htmlString;
   }
 }

--- a/packages/hdot/src/hdot.ts
+++ b/packages/hdot/src/hdot.ts
@@ -1,28 +1,22 @@
 import {
-  fakeBaseClass,
   isTemplateParam,
   rawTemplate,
   keyIsOmitted,
 } from "./utils";
-import { HTMLElements, PluginArray, TreeNode } from "./types";
-export * from "./types";
+import { BaseHTMLElements as HTMLElements, PluginArray, TreeNode } from "./types";
 
-export class hdot extends fakeBaseClass<HTMLElements>() {
-  constructor(plugins: PluginArray = []) {
-    super();
-
-    return new Proxy(this, {
-      get(target, key, reciever) {
-        if (keyIsOmitted(key, "toString")) {
-          return Reflect.get(target, key, reciever);
-        }
-        return new hdotElement(key, plugins);
-      },
-    }) as HTMLElements;
-  }
+export const hdot = <CustomElements = {}>(plugins: PluginArray = []) => {
+  return new Proxy({}, {
+    get(target, key, reciever) {
+      if (keyIsOmitted(key, "toString")) {
+        return Reflect.get(target, key, reciever);
+      }
+      return new hdotElement(key, plugins);
+    },
+  }) as HTMLElements;
 }
 
-export const h = new hdot();
+export const h = hdot();
 
 class hdotElement extends Function {
   private treeNode: TreeNode;

--- a/packages/hdot/src/types/generate.js
+++ b/packages/hdot/src/types/generate.js
@@ -85,7 +85,7 @@ const writeGlobalAttributes = (content, htmlSpec) => {
     "[dataAttribute: `data${string}`]",
     `(value: string | boolean | number) => HTMLElements[TagName]`
   );
-  htmlDef.addProperty(`(...children: children)`, `string`);
+  htmlDef.addProperty(`(...children: children)`, `HTMLElements[TagName]`);
   content.push(htmlDef.toString());
 
   const ariaDef = new TypeDef(

--- a/packages/hdot/src/types/html.ts
+++ b/packages/hdot/src/types/html.ts
@@ -1,2002 +1,1700 @@
 // WARNING: This file was auto-generated and any changes will be overwritten.
-export type HTMLElements = {
+export type BaseHTMLElements = {
   /** The <a> HTML element (or anchor element), with its href attribute, creates a hyperlink to web pages, files, email addresses, locations in the same page, or anything else a URL can address. */
-  a: aElement;
+  "a": aElement;
   /** The <abbr> HTML element represents an abbreviation or acronym; the optional title attribute can provide an expansion or description for the abbreviation. If present, title must contain this full description and nothing else. */
-  abbr: abbrElement;
+  "abbr": abbrElement;
   /** @deprecated The <acronym> HTML element allows authors to clearly indicate a sequence of characters that compose an acronym or abbreviation for a word. */
-  acronym: acronymElement;
+  "acronym": acronymElement;
   /** The <address> HTML element indicates that the enclosed HTML provides contact information for a person or people, or for an organization. */
-  address: addressElement;
+  "address": addressElement;
   /** @deprecated The obsolete HTML Applet Element (<applet>) embeds a Java applet into the document; this element has been deprecated in favor of <object>. */
-  applet: appletElement;
+  "applet": appletElement;
   /** The <area> HTML element defines an area inside an image map that has predefined clickable areas. An image map allows geometric areas on an image to be associated with hypertext link. */
-  area: areaElement;
+  "area": areaElement;
   /** The <article> HTML element represents a self-contained composition in a document, page, application, or site, which is intended to be independently distributable or reusable (e.g., in syndication). Examples include: a forum post, a magazine or newspaper article, or a blog entry, a product card, a user-submitted comment, an interactive widget or gadget, or any other independent item of content. */
-  article: articleElement;
+  "article": articleElement;
   /** The <aside> HTML element represents a portion of a document whose content is only indirectly related to the document's main content. Asides are frequently presented as sidebars or call-out boxes. */
-  aside: asideElement;
+  "aside": asideElement;
   /** The <audio> HTML element is used to embed sound content in documents. It may contain one or more audio sources, represented using the src attribute or the <source> element: the browser will choose the most suitable one. It can also be the destination for streamed media, using a MediaStream. */
-  audio: audioElement;
+  "audio": audioElement;
   /** The <b> HTML element is used to draw the reader's attention to the element's contents, which are not otherwise granted special importance. This was formerly known as the Boldface element, and most browsers still draw the text in boldface. However, you should not use <b> for styling text; instead, you should use the CSS font-weight property to create boldface text, or the <strong> element to indicate that text is of special importance. */
-  b: bElement;
+  "b": bElement;
   /** The <base> HTML element specifies the base URL to use for all relative URLs in a document. There can be only one <base> element in a document. */
-  base: baseElement;
+  "base": baseElement;
   /** @deprecated The <basefont> HTML element is deprecated. It sets a default font face, size, and color for the other elements which are descended from its parent element. With this set, the font's size can then be varied relative to the base size using the <font> element. */
-  basefont: basefontElement;
+  "basefont": basefontElement;
   /** The <bdi> HTML element tells the browser's bidirectional algorithm to treat the text it contains in isolation from its surrounding text. It's particularly useful when a website dynamically inserts some text and doesn't know the directionality of the text being inserted. */
-  bdi: bdiElement;
+  "bdi": bdiElement;
   /** The <bdo> HTML element overrides the current directionality of text, so that the text within is rendered in a different direction. */
-  bdo: bdoElement;
+  "bdo": bdoElement;
   /** @deprecated The <bgsound> HTML element is deprecated. It sets up a sound file to play in the background while the page is used; use <audio> instead. */
-  bgsound: bgsoundElement;
+  "bgsound": bgsoundElement;
   /** @deprecated The <big> HTML deprecated element renders the enclosed text at a font size one level larger than the surrounding text (medium becomes large, for example). The size is capped at the browser's maximum permitted font size. */
-  big: bigElement;
+  "big": bigElement;
   /** @deprecated The <blink> HTML element is a non-standard element which causes the enclosed text to flash slowly. */
-  blink: blinkElement;
+  "blink": blinkElement;
   /** The <blockquote> HTML element indicates that the enclosed text is an extended quotation. Usually, this is rendered visually by indentation (see Notes for how to change it). A URL for the source of the quotation may be given using the cite attribute, while a text representation of the source can be given using the <cite> element. */
-  blockquote: blockquoteElement;
+  "blockquote": blockquoteElement;
   /** The <body> HTML element represents the content of an HTML document. There can be only one <body> element in a document. */
-  body: bodyElement;
+  "body": bodyElement;
   /** The <br> HTML element produces a line break in text (carriage-return). It is useful for writing a poem or an address, where the division of lines is significant. */
-  br: brElement;
+  "br": brElement;
   /** The <button> HTML element represents a clickable button, used to submit forms or anywhere in a document for accessible, standard button functionality. */
-  button: buttonElement;
+  "button": buttonElement;
   /** Use the HTML <canvas> element with either the canvas scripting API or the WebGL API to draw graphics and animations. */
-  canvas: canvasElement;
+  "canvas": canvasElement;
   /** The <caption> HTML element specifies the caption (or title) of a table. */
-  caption: captionElement;
+  "caption": captionElement;
   /** @deprecated The <center> HTML element is a block-level element that displays its block-level or inline contents centered horizontally within its containing element. The container is usually, but isn't required to be, <body>. */
-  center: centerElement;
+  "center": centerElement;
   /** The <cite> HTML element is used to describe a reference to a cited creative work, and must include the title of that work. The reference may be in an abbreviated form according to context-appropriate conventions related to citation metadata. */
-  cite: citeElement;
+  "cite": citeElement;
   /** The <code> HTML element displays its contents styled in a fashion intended to indicate that the text is a short fragment of computer code. By default, the content text is displayed using the user agent's default monospace font. */
-  code: codeElement;
+  "code": codeElement;
   /** The <col> HTML element defines a column within a table and is used for defining common semantics on all common cells. It is generally found within a <colgroup> element. */
-  col: colElement;
+  "col": colElement;
   /** The <colgroup> HTML element defines a group of columns within a table. */
-  colgroup: colgroupElement;
+  "colgroup": colgroupElement;
   /** @deprecated The <content> HTML element—an obsolete part of the Web Components suite of technologies—was used inside of Shadow DOM as an insertion point, and wasn't meant to be used in ordinary HTML. It has now been replaced by the <slot> element, which creates a point in the DOM at which a shadow DOM can be inserted. */
-  content: contentElement;
+  "content": contentElement;
   /** The <data> HTML element links a given piece of content with a machine-readable translation. If the content is time- or date-related, the <time> element must be used. */
-  data: dataElement;
+  "data": dataElement;
   /** The <datalist> HTML element contains a set of <option> elements that represent the permissible or recommended options available to choose from within other controls. */
-  datalist: datalistElement;
+  "datalist": datalistElement;
   /** The <dd> HTML element provides the description, definition, or value for the preceding term (<dt>) in a description list (<dl>). */
-  dd: ddElement;
+  "dd": ddElement;
   /** The <del> HTML element represents a range of text that has been deleted from a document. This can be used when rendering "track changes" or source code diff information, for example. The <ins> element can be used for the opposite purpose: to indicate text that has been added to the document. */
-  del: delElement;
+  "del": delElement;
   /** The <details> HTML element creates a disclosure widget in which information is visible only when the widget is toggled into an "open" state. A summary or label must be provided using the <summary> element. */
-  details: detailsElement;
+  "details": detailsElement;
   /** The <dfn> HTML element is used to indicate the term being defined within the context of a definition phrase or sentence. The <p> element, the <dt>/<dd> pairing, or the <section> element which is the nearest ancestor of the <dfn> is considered to be the definition of the term. */
-  dfn: dfnElement;
+  "dfn": dfnElement;
   /** The <dialog> HTML element represents a dialog box or other interactive component, such as a dismissible alert, inspector, or subwindow. */
-  dialog: dialogElement;
+  "dialog": dialogElement;
   /** @deprecated The <dir> HTML element is used as a container for a directory of files and/or folders, potentially with styles and icons applied by the user agent. Do not use this obsolete element; instead, you should use the <ul> element for lists, including lists of files. */
-  dir: dirElement;
+  "dir": dirElement;
   /** The <div> HTML element is the generic container for flow content. It has no effect on the content or layout until styled in some way using CSS (e.g. styling is directly applied to it, or some kind of layout model like Flexbox is applied to its parent element). */
-  div: divElement;
+  "div": divElement;
   /** The <dl> HTML element represents a description list. The element encloses a list of groups of terms (specified using the <dt> element) and descriptions (provided by <dd> elements). Common uses for this element are to implement a glossary or to display metadata (a list of key-value pairs). */
-  dl: dlElement;
+  "dl": dlElement;
   /** The <dt> HTML element specifies a term in a description or definition list, and as such must be used inside a <dl> element. It is usually followed by a <dd> element; however, multiple <dt> elements in a row indicate several terms that are all defined by the immediate next <dd> element. */
-  dt: dtElement;
+  "dt": dtElement;
   /** The <em> HTML element marks text that has stress emphasis. The <em> element can be nested, with each level of nesting indicating a greater degree of emphasis. */
-  em: emElement;
+  "em": emElement;
   /** The <embed> HTML element embeds external content at the specified point in the document. This content is provided by an external application or other source of interactive content such as a browser plug-in. */
-  embed: embedElement;
+  "embed": embedElement;
   /** The <fieldset> HTML element is used to group several controls as well as labels (<label>) within a web form. */
-  fieldset: fieldsetElement;
+  "fieldset": fieldsetElement;
   /** The <figcaption> HTML element represents a caption or legend describing the rest of the contents of its parent <figure> element. */
-  figcaption: figcaptionElement;
+  "figcaption": figcaptionElement;
   /** The <figure> HTML element represents self-contained content, potentially with an optional caption, which is specified using the <figcaption> element. The figure, its caption, and its contents are referenced as a single unit. */
-  figure: figureElement;
+  "figure": figureElement;
   /** @deprecated The <font> HTML element defines the font size, color and face for its content. */
-  font: fontElement;
+  "font": fontElement;
   /** The <footer> HTML element represents a footer for its nearest sectioning content or sectioning root element. A <footer> typically contains information about the author of the section, copyright data or links to related documents. */
-  footer: footerElement;
+  "footer": footerElement;
   /** The <form> HTML element represents a document section containing interactive controls for submitting information. */
-  form: formElement;
+  "form": formElement;
   /** @deprecated The <frame> HTML element defines a particular area in which another HTML document can be displayed. A frame should be used within a <frameset>. */
-  frame: frameElement;
+  "frame": frameElement;
   /** @deprecated The <frameset> HTML element is used to contain <frame> elements. */
-  frameset: framesetElement;
+  "frameset": framesetElement;
   /** The <h1> to <h6> HTML elements represent six levels of section headings. <h1> is the highest section level and <h6> is the lowest. */
-  h1: h1Element;
+  "h1": h1Element;
   /** The <h1> to <h6> HTML elements represent six levels of section headings. <h1> is the highest section level and <h6> is the lowest. */
-  h2: h2Element;
+  "h2": h2Element;
   /** The <h1> to <h6> HTML elements represent six levels of section headings. <h1> is the highest section level and <h6> is the lowest. */
-  h3: h3Element;
+  "h3": h3Element;
   /** The <h1> to <h6> HTML elements represent six levels of section headings. <h1> is the highest section level and <h6> is the lowest. */
-  h4: h4Element;
+  "h4": h4Element;
   /** The <h1> to <h6> HTML elements represent six levels of section headings. <h1> is the highest section level and <h6> is the lowest. */
-  h5: h5Element;
+  "h5": h5Element;
   /** The <head> HTML element contains machine-readable information (metadata) about the document, like its title, scripts, and style sheets. */
-  head: headElement;
+  "head": headElement;
   /** The <header> HTML element represents introductory content, typically a group of introductory or navigational aids. It may contain some heading elements but also a logo, a search form, an author name, and other elements. */
-  header: headerElement;
+  "header": headerElement;
   /** The <hgroup> HTML element represents a multi-level heading for a section of a document. It groups a set of <h1>–<h6> elements. */
-  hgroup: hgroupElement;
+  "hgroup": hgroupElement;
   /** The <hr> HTML element represents a thematic break between paragraph-level elements: for example, a change of scene in a story, or a shift of topic within a section. */
-  hr: hrElement;
+  "hr": hrElement;
   /** The <html> HTML element represents the root (top-level element) of an HTML document, so it is also referred to as the root element. All other elements must be descendants of this element. */
-  html: htmlElement;
+  "html": htmlElement;
   /** The <i> HTML element represents a range of text that is set off from the normal text for some reason, such as idiomatic text, technical terms, taxonomical designations, among others. Historically, these have been presented using italicized type, which is the original source of the <i> naming of this element. */
-  i: iElement;
+  "i": iElement;
   /** The <iframe> HTML element represents a nested browsing context, embedding another HTML page into the current one. */
-  iframe: iframeElement;
+  "iframe": iframeElement;
   /** @deprecated The <image> HTML element is an ancient and poorly supported precursor to the <img> element. It should not be used. */
-  image: imageElement;
+  "image": imageElement;
   /** The <img> HTML element embeds an image into the document. */
-  img: imgElement;
+  "img": imgElement;
   /** The <input> HTML element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent. The <input> element is one of the most powerful and complex in all of HTML due to the sheer number of combinations of input types and attributes. */
-  input: inputElement;
+  "input": inputElement;
   /** The <ins> HTML element represents a range of text that has been added to a document. You can use the <del> element to similarly represent a range of text that has been deleted from the document. */
-  ins: insElement;
+  "ins": insElement;
   /** Element is entirely obsolete, and must not be used by authors. */
-  isindex: isindexElement;
+  "isindex": isindexElement;
   /** The <kbd> HTML element represents a span of inline text denoting textual user input from a keyboard, voice input, or any other text entry device. By convention, the user agent defaults to rendering the contents of a <kbd> element using its default monospace font, although this is not mandated by the HTML standard. */
-  kbd: kbdElement;
+  "kbd": kbdElement;
   /** @deprecated The <keygen> HTML element exists to facilitate generation of key material, and submission of the public key as part of an HTML form. This mechanism is designed for use with Web-based certificate management systems. It is expected that the <keygen> element will be used in an HTML form along with other information needed to construct a certificate request, and that the result of the process will be a signed certificate. */
-  keygen: keygenElement;
+  "keygen": keygenElement;
   /** The <label> HTML element represents a caption for an item in a user interface. */
-  label: labelElement;
+  "label": labelElement;
   /** The <legend> HTML element represents a caption for the content of its parent <fieldset>. */
-  legend: legendElement;
+  "legend": legendElement;
   /** The <li> HTML element is used to represent an item in a list. It must be contained in a parent element: an ordered list (<ol>), an unordered list (<ul>), or a menu (<menu>). In menus and unordered lists, list items are usually displayed using bullet points. In ordered lists, they are usually displayed with an ascending counter on the left, such as a number or letter. */
-  li: liElement;
+  "li": liElement;
   /** The <link> HTML element specifies relationships between the current document and an external resource. This element is most commonly used to link to stylesheets, but is also used to establish site icons (both "favicon" style icons and icons for the home screen and apps on mobile devices) among other things. */
-  link: linkElement;
+  "link": linkElement;
   /** Element is entirely obsolete, and must not be used by authors. */
-  listing: listingElement;
+  "listing": listingElement;
   /** The <main> HTML element represents the dominant content of the <body> of a document. The main content area consists of content that is directly related to or expands upon the central topic of a document, or the central functionality of an application. */
-  main: mainElement;
+  "main": mainElement;
   /** The <map> HTML element is used with <area> elements to define an image map (a clickable link area). */
-  map: mapElement;
+  "map": mapElement;
   /** The <mark> HTML element represents text which is marked or highlighted for reference or notation purposes, due to the marked passage's relevance or importance in the enclosing context. */
-  mark: markElement;
+  "mark": markElement;
   /** @deprecated The <marquee> HTML element is used to insert a scrolling area of text. You can control what happens when the text reaches the edges of its content area using its attributes. */
-  marquee: marqueeElement;
+  "marquee": marqueeElement;
   /** The <menu> HTML element is a semantic alternative to <ul>. It represents an unordered list of items (represented by <li> elements), each of these represent a link or other command that the user can activate. */
-  menu: menuElement;
+  "menu": menuElement;
   /** @deprecated The <menuitem> HTML element represents a command that a user is able to invoke through a popup menu. This includes context menus, as well as menus that might be attached to a menu button. */
-  menuitem: menuitemElement;
+  "menuitem": menuitemElement;
   /** The <meta> HTML element represents metadata that cannot be represented by other HTML meta-related elements, like <base>, <link>, <script>, <style> or <title>. */
-  meta: metaElement;
+  "meta": metaElement;
   /** The <meter> HTML element represents either a scalar value within a known range or a fractional value. */
-  meter: meterElement;
+  "meter": meterElement;
   /** Element is entirely obsolete, and must not be used by authors. */
-  multicol: multicolElement;
+  "multicol": multicolElement;
   /** The <nav> HTML element represents a section of a page whose purpose is to provide navigation links, either within the current document or to other documents. Common examples of navigation sections are menus, tables of contents, and indexes. */
-  nav: navElement;
+  "nav": navElement;
   /** Element is entirely obsolete, and must not be used by authors. */
-  nextid: nextidElement;
+  "nextid": nextidElement;
   /** @deprecated The <nobr> HTML element prevents the text it contains from automatically wrapping across multiple lines, potentially resulting in the user having to scroll horizontally to see the entire width of the text. */
-  nobr: nobrElement;
+  "nobr": nobrElement;
   /** @deprecated The <noembed> HTML element is an obsolete, non-standard way to provide alternative, or "fallback", content for browsers that do not support the <embed> element or do not support the type of embedded content an author wishes to use. This element was deprecated in HTML 4.01 and above in favor of placing fallback content between the opening and closing tags of an <object> element. */
-  noembed: noembedElement;
+  "noembed": noembedElement;
   /** @deprecated The <noframes> HTML element provides content to be presented in browsers that don't support (or have disabled support for) the <frame> element. Although most commonly-used browsers support frames, there are exceptions, including certain special-use browsers including some mobile browsers, as well as text-mode browsers. */
-  noframes: noframesElement;
+  "noframes": noframesElement;
   /** The <noscript> HTML element defines a section of HTML to be inserted if a script type on the page is unsupported or if scripting is currently turned off in the browser. */
-  noscript: noscriptElement;
+  "noscript": noscriptElement;
   /** The <object> HTML element represents an external resource, which can be treated as an image, a nested browsing context, or a resource to be handled by a plugin. */
-  object: objectElement;
+  "object": objectElement;
   /** The <ol> HTML element represents an ordered list of items — typically rendered as a numbered list. */
-  ol: olElement;
+  "ol": olElement;
   /** The <optgroup> HTML element creates a grouping of options within a <select> element. */
-  optgroup: optgroupElement;
+  "optgroup": optgroupElement;
   /** The <option> HTML element is used to define an item contained in a <select>, an <optgroup>, or a <datalist> element. As such, <option> can represent menu items in popups and other lists of items in an HTML document. */
-  option: optionElement;
+  "option": optionElement;
   /** The <output> HTML element is a container element into which a site or app can inject the results of a calculation or the outcome of a user action. */
-  output: outputElement;
+  "output": outputElement;
   /** The <p> HTML element represents a paragraph. Paragraphs are usually represented in visual media as blocks of text separated from adjacent blocks by blank lines and/or first-line indentation, but HTML paragraphs can be any structural grouping of related content, such as images or form fields. */
-  p: pElement;
+  "p": pElement;
   /** The <param> HTML element defines parameters for an <object> element. */
-  param: paramElement;
+  "param": paramElement;
   /** The <picture> HTML element contains zero or more <source> elements and one <img> element to offer alternative versions of an image for different display/device scenarios. */
-  picture: pictureElement;
+  "picture": pictureElement;
   /** @deprecated The <plaintext> HTML element renders everything following the start tag as raw text, ignoring any following HTML. There is no closing tag, since everything after it is considered raw text. */
-  plaintext: plaintextElement;
+  "plaintext": plaintextElement;
   /** The <portal> HTML element enables the embedding of another HTML page into the current one for the purposes of allowing smoother navigation into new pages. */
-  portal: portalElement;
+  "portal": portalElement;
   /** The <pre> HTML element represents preformatted text which is to be presented exactly as written in the HTML file. The text is typically rendered using a non-proportional, or "monospaced, font. Whitespace inside this element is displayed as written. */
-  pre: preElement;
+  "pre": preElement;
   /** The <progress> HTML element displays an indicator showing the completion progress of a task, typically displayed as a progress bar. */
-  progress: progressElement;
+  "progress": progressElement;
   /** The <q> HTML element indicates that the enclosed text is a short inline quotation. Most modern browsers implement this by surrounding the text in quotation marks. This element is intended for short quotations that don't require paragraph breaks; for long quotations use the <blockquote> element. */
-  q: qElement;
+  "q": qElement;
   /** @deprecated The <rb> HTML element is used to delimit the base text component of a <ruby> annotation, i.e. the text that is being annotated. One <rb> element should wrap each separate atomic segment of the base text. */
-  rb: rbElement;
+  "rb": rbElement;
   /** The <rp> HTML element is used to provide fall-back parentheses for browsers that do not support display of ruby annotations using the <ruby> element. One <rp> element should enclose each of the opening and closing parentheses that wrap the <rt> element that contains the annotation's text. */
-  rp: rpElement;
+  "rp": rpElement;
   /** The <rt> HTML element specifies the ruby text component of a ruby annotation, which is used to provide pronunciation, translation, or transliteration information for East Asian typography. The <rt> element must always be contained within a <ruby> element. */
-  rt: rtElement;
+  "rt": rtElement;
   /** @deprecated The <rtc> HTML element embraces semantic annotations of characters presented in a ruby of <rb> elements used inside of <ruby> element. <rb> elements can have both pronunciation (<rt>) and semantic (<rtc>) annotations. */
-  rtc: rtcElement;
+  "rtc": rtcElement;
   /** The <ruby> HTML element represents small annotations that are rendered above, below, or next to base text, usually used for showing the pronunciation of East Asian characters. It can also be used for annotating other kinds of text, but this usage is less common. */
-  ruby: rubyElement;
+  "ruby": rubyElement;
   /** The <s> HTML element renders text with a strikethrough, or a line through it. Use the <s> element to represent things that are no longer relevant or no longer accurate. However, <s> is not appropriate when indicating document edits; for that, use the <del> and <ins> elements, as appropriate. */
-  s: sElement;
+  "s": sElement;
   /** The <samp> HTML element is used to enclose inline text which represents sample (or quoted) output from a computer program. Its contents are typically rendered using the browser's default monospaced font (such as Courier or Lucida Console). */
-  samp: sampElement;
+  "samp": sampElement;
   /** The <script> HTML element is used to embed executable code or data; this is typically used to embed or refer to JavaScript code. The <script> element can also be used with other languages, such as WebGL's GLSL shader programming language and JSON. */
-  script: scriptElement;
+  "script": scriptElement;
   /** The <section> HTML element represents a generic standalone section of a document, which doesn't have a more specific semantic element to represent it. Sections should always have a heading, with very few exceptions. */
-  section: sectionElement;
+  "section": sectionElement;
   /** The <select> HTML element represents a control that provides a menu of options: */
-  select: selectElement;
+  "select": selectElement;
   /** @deprecated The <shadow> HTML element—an obsolete part of the Web Components technology suite—was intended to be used as a shadow DOM insertion point. You might have used it if you have created multiple shadow roots under a shadow host. It is not useful in ordinary HTML. */
-  shadow: shadowElement;
+  "shadow": shadowElement;
   /** The <slot> HTML element—part of the Web Components technology suite—is a placeholder inside a web component that you can fill with your own markup, which lets you create separate DOM trees and present them together. */
-  slot: slotElement;
+  "slot": slotElement;
   /** The <small> HTML element represents side-comments and small print, like copyright and legal text, independent of its styled presentation. By default, it renders text within it one font-size smaller, such as from small to x-small. */
-  small: smallElement;
+  "small": smallElement;
   /** The <source> HTML element specifies multiple media resources for the <picture>, the <audio> element, or the <video> element. It is an empty element, meaning that it has no content and does not have a closing tag. It is commonly used to offer the same media content in multiple file formats in order to provide compatibility with a broad range of browsers given their differing support for image file formats and media file formats. */
-  source: sourceElement;
+  "source": sourceElement;
   /** @deprecated The <spacer> HTML element is an obsolete HTML element which allowed insertion of empty spaces on pages. It was devised by Netscape to accomplish the same effect as a single-pixel layout image, which was something web designers used to use to add white spaces to web pages without actually using an image. However, <spacer> no longer supported by any major browser and the same effects can now be achieved using simple CSS. */
-  spacer: spacerElement;
+  "spacer": spacerElement;
   /** The <span> HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. <span> is very much like a <div> element, but <div> is a block-level element whereas a <span> is an inline element. */
-  span: spanElement;
+  "span": spanElement;
   /** @deprecated The <strike> HTML element places a strikethrough (horizontal line) over text. */
-  strike: strikeElement;
+  "strike": strikeElement;
   /** The <strong> HTML element indicates that its contents have strong importance, seriousness, or urgency. Browsers typically render the contents in bold type. */
-  strong: strongElement;
+  "strong": strongElement;
   /** The <style> HTML element contains style information for a document, or part of a document. It contains CSS, which is applied to the contents of the document containing the <style> element. */
-  style: styleElement;
+  "style": styleElement;
   /** The <sub> HTML element specifies inline text which should be displayed as subscript for solely typographical reasons. Subscripts are typically rendered with a lowered baseline using smaller text. */
-  sub: subElement;
+  "sub": subElement;
   /** The <summary> HTML element specifies a summary, caption, or legend for a <details> element's disclosure box. Clicking the <summary> element toggles the state of the parent <details> element open and closed. */
-  summary: summaryElement;
+  "summary": summaryElement;
   /** The <sup> HTML element specifies inline text which is to be displayed as superscript for solely typographical reasons. Superscripts are usually rendered with a raised baseline using smaller text. */
-  sup: supElement;
+  "sup": supElement;
   /** The <table> HTML element represents tabular data — that is, information presented in a two-dimensional table comprised of rows and columns of cells containing data. */
-  table: tableElement;
+  "table": tableElement;
   /** The <tbody> HTML element encapsulates a set of table rows (<tr> elements), indicating that they comprise the body of the table (<table>). */
-  tbody: tbodyElement;
+  "tbody": tbodyElement;
   /** The <td> HTML element defines a cell of a table that contains data. It participates in the table model. */
-  td: tdElement;
+  "td": tdElement;
   /** The <template> HTML element is a mechanism for holding HTML that is not to be rendered immediately when a page is loaded but may be instantiated subsequently during runtime using JavaScript. */
-  template: templateElement;
+  "template": templateElement;
   /** The <textarea> HTML element represents a multi-line plain-text editing control, useful when you want to allow users to enter a sizeable amount of free-form text, for example a comment on a review or feedback form. */
-  textarea: textareaElement;
+  "textarea": textareaElement;
   /** The <tfoot> HTML element defines a set of rows summarizing the columns of the table. */
-  tfoot: tfootElement;
+  "tfoot": tfootElement;
   /** The <th> HTML element defines a cell as header of a group of table cells. The exact nature of this group is defined by the scope and headers attributes. */
-  th: thElement;
+  "th": thElement;
   /** The <thead> HTML element defines a set of rows defining the head of the columns of the table. */
-  thead: theadElement;
+  "thead": theadElement;
   /** The <time> HTML element represents a specific period in time. It may include the datetime attribute to translate dates into machine-readable format, allowing for better search engine results or custom features such as reminders. */
-  time: timeElement;
+  "time": timeElement;
   /** The <title> HTML element defines the document's title that is shown in a browser's title bar or a page's tab. It only contains text; tags within the element are ignored. */
-  title: titleElement;
+  "title": titleElement;
   /** The <tr> HTML element defines a row of cells in a table. The row's cells can then be established using a mix of <td> (data cell) and <th> (header cell) elements. */
-  tr: trElement;
+  "tr": trElement;
   /** The <track> HTML element is used as a child of the media elements, <audio> and <video>. It lets you specify timed text tracks (or time-based data), for example to automatically handle subtitles. The tracks are formatted in WebVTT format (.vtt files) — Web Video Text Tracks. */
-  track: trackElement;
+  "track": trackElement;
   /** @deprecated The <tt> HTML element creates inline text which is presented using the user agent's default monospace font face. This element was created for the purpose of rendering text as it would be displayed on a fixed-width display such as a teletype, text-only screen, or line printer. */
-  tt: ttElement;
+  "tt": ttElement;
   /** The <u> HTML element represents a span of inline text which should be rendered in a way that indicates that it has a non-textual annotation. This is rendered by default as a simple solid underline, but may be altered using CSS. */
-  u: uElement;
+  "u": uElement;
   /** The <ul> HTML element represents an unordered list of items, typically rendered as a bulleted list. */
-  ul: ulElement;
+  "ul": ulElement;
   /** The <var> HTML element represents the name of a variable in a mathematical expression or a programming context. It's typically presented using an italicized version of the current typeface, although that behavior is browser-dependent. */
-  var: varElement;
+  "var": varElement;
   /** The <video> HTML element embeds a media player which supports video playback into the document. You can use <video> for audio content as well, but the <audio> element may provide a more appropriate user experience. */
-  video: videoElement;
+  "video": videoElement;
   /** The <wbr> HTML element represents a word break opportunity—a position within text where the browser may optionally break a line, though its line-breaking rules would not otherwise create a break at that location. */
-  wbr: wbrElement;
+  "wbr": wbrElement;
   /** @deprecated The <xmp> HTML element renders text between the start and end tags without interpreting the HTML in between and using a monospaced font. The HTML2 specification recommended that it should be rendered wide enough to allow 80 characters per line. */
-  xmp: xmpElement;
+  "xmp": xmpElement;
 };
 
-type children = (
-  | string
-  | TemplateStringsArray
-  | HTMLElements[keyof HTMLElements]
-)[];
-type GlobalHTMLAttributes<TagName extends keyof HTMLElements> = {
+type children = (string | TemplateStringsArray | BaseHTMLElements[keyof BaseHTMLElements])[]
+export type GlobalHTMLAttributes<ReturnElement> = {
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-accesskey */
-  accesskey: (value: string) => HTMLElements[TagName];
+  "accesskey": (value: string) => ReturnElement;
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-autocapitalize */
-  autocapitalize: (
-    value: "off" | "on" | "none" | "sentences" | "words" | "characters"
-  ) => HTMLElements[TagName];
+  "autocapitalize": (value: "off" | "on" | "none" | "sentences" | "words" | "characters") => ReturnElement;
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-autofocus */
-  autofocus: (value: boolean) => HTMLElements[TagName];
+  "autofocus": (value: boolean) => ReturnElement;
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-contenteditable */
-  contenteditable: (value: "" | "true" | "false") => HTMLElements[TagName];
+  "contenteditable": (value: "" | "true" | "false") => ReturnElement;
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-dir */
-  dir: (value: "ltr" | "rtl" | "auto") => HTMLElements[TagName];
+  "dir": (value: "ltr" | "rtl" | "auto") => ReturnElement;
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-draggable */
-  draggable: (value: "true" | "false") => HTMLElements[TagName];
+  "draggable": (value: "true" | "false") => ReturnElement;
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-enterkeyhint */
-  enterkeyhint: (
-    value: "enter" | "done" | "go" | "next" | "previous" | "search" | "send"
-  ) => HTMLElements[TagName];
+  "enterkeyhint": (value: "enter" | "done" | "go" | "next" | "previous" | "search" | "send") => ReturnElement;
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-hidden */
-  hidden: (value: boolean) => HTMLElements[TagName];
+  "hidden": (value: boolean) => ReturnElement;
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-inert */
-  inert: (value: boolean) => HTMLElements[TagName];
+  "inert": (value: boolean) => ReturnElement;
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-inputmode */
-  inputmode: (
-    value:
-      | "none"
-      | "text"
-      | "tel"
-      | "url"
-      | "email"
-      | "numeric"
-      | "decimal"
-      | "search"
-  ) => HTMLElements[TagName];
+  "inputmode": (value: "none" | "text" | "tel" | "url" | "email" | "numeric" | "decimal" | "search") => ReturnElement;
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-is */
-  is: (value: `${string}-${string}`) => HTMLElements[TagName];
+  "is": (value: `${string}-${string}`) => ReturnElement;
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-itemid */
-  itemid: (value: string) => HTMLElements[TagName];
+  "itemid": (value: string) => ReturnElement;
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-itemprop */
-  itemprop: (value: string) => HTMLElements[TagName];
+  "itemprop": (value: string) => ReturnElement;
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-itemref */
-  itemref: (value: string) => HTMLElements[TagName];
+  "itemref": (value: string) => ReturnElement;
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-itemscope */
-  itemscope: (value: boolean) => HTMLElements[TagName];
+  "itemscope": (value: boolean) => ReturnElement;
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-itemtype */
-  itemtype: (value: string) => HTMLElements[TagName];
+  "itemtype": (value: string) => ReturnElement;
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-lang */
-  lang: (value: string) => HTMLElements[TagName];
+  "lang": (value: string) => ReturnElement;
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-nonce */
-  nonce: (value: string) => HTMLElements[TagName];
+  "nonce": (value: string) => ReturnElement;
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-spellcheck */
-  spellcheck: (value: "" | "true" | "false") => HTMLElements[TagName];
+  "spellcheck": (value: "" | "true" | "false") => ReturnElement;
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-style */
-  style: (value: string) => HTMLElements[TagName];
+  "style": (value: string) => ReturnElement;
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-tabindex */
-  tabindex: (value: number) => HTMLElements[TagName];
+  "tabindex": (value: number) => ReturnElement;
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-title */
-  title: (value: string) => HTMLElements[TagName];
+  "title": (value: string) => ReturnElement;
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-translate */
-  translate: (value: "" | "yes" | "no") => HTMLElements[TagName];
+  "translate": (value: "" | "yes" | "no") => ReturnElement;
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-class */
-  class: (value: string) => HTMLElements[TagName];
+  "class": (value: string) => ReturnElement;
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-id */
-  id: (value: string) => HTMLElements[TagName];
+  "id": (value: string) => ReturnElement;
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-slot */
-  slot: (value: string) => HTMLElements[TagName];
+  "slot": (value: string) => ReturnElement;
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-xmlns */
-  xmlns: (value: string) => HTMLElements[TagName];
+  "xmlns": (value: string) => ReturnElement;
   /** @deprecated @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-xml:lang */
-  "xml:lang": (value: string) => HTMLElements[TagName];
+  "xml:lang": (value: string) => ReturnElement;
   /** @deprecated @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-xml:space */
-  "xml:space": (value: "default" | "preserve") => HTMLElements[TagName];
-  [dataAttribute: `data${string}`]: (
-    value: string | boolean | number
-  ) => HTMLElements[TagName];
-  (...children: children): HTMLElements[TagName];
+  "xml:space": (value: "default" | "preserve") => ReturnElement;
+  [dataAttribute: `data${string}`]: (value: string | boolean | number) => ReturnElement;
+  (...children: children): ReturnElement;
 };
 
-type GlobalAriaAttributes<TagName extends keyof HTMLElements> = {
-  ariaActivedescendant: (value: string) => HTMLElements[TagName];
-  ariaAtomic: (value: string) => HTMLElements[TagName];
-  ariaAutocomplete: (value: string) => HTMLElements[TagName];
-  ariaBusy: (value: string) => HTMLElements[TagName];
-  ariaChecked: (value: string) => HTMLElements[TagName];
-  ariaColcount: (value: string) => HTMLElements[TagName];
-  ariaColindex: (value: string) => HTMLElements[TagName];
-  ariaColspan: (value: string) => HTMLElements[TagName];
-  ariaControls: (value: string) => HTMLElements[TagName];
-  ariaCurrent: (value: string) => HTMLElements[TagName];
-  ariaDescribedby: (value: string) => HTMLElements[TagName];
-  ariaDetails: (value: string) => HTMLElements[TagName];
-  ariaDisabled: (value: string) => HTMLElements[TagName];
-  ariaDropeffect: (value: string) => HTMLElements[TagName];
-  ariaErrormessage: (value: string) => HTMLElements[TagName];
-  ariaExpanded: (value: string) => HTMLElements[TagName];
-  ariaFlowto: (value: string) => HTMLElements[TagName];
-  ariaGrabbed: (value: string) => HTMLElements[TagName];
-  ariaHaspopup: (value: string) => HTMLElements[TagName];
-  ariaHidden: (value: string) => HTMLElements[TagName];
-  ariaInvalid: (value: string) => HTMLElements[TagName];
-  ariaKeyshortcuts: (value: string) => HTMLElements[TagName];
-  ariaLabel: (value: string) => HTMLElements[TagName];
-  ariaLabelledby: (value: string) => HTMLElements[TagName];
-  ariaLevel: (value: string) => HTMLElements[TagName];
-  ariaLive: (value: string) => HTMLElements[TagName];
-  ariaModal: (value: string) => HTMLElements[TagName];
-  ariaMultiline: (value: string) => HTMLElements[TagName];
-  ariaMultiselectable: (value: string) => HTMLElements[TagName];
-  ariaOrientation: (value: string) => HTMLElements[TagName];
-  ariaOwns: (value: string) => HTMLElements[TagName];
-  ariaPlaceholder: (value: string) => HTMLElements[TagName];
-  ariaPosinset: (value: string) => HTMLElements[TagName];
-  ariaPressed: (value: string) => HTMLElements[TagName];
-  ariaReadonly: (value: string) => HTMLElements[TagName];
-  ariaRelevant: (value: string) => HTMLElements[TagName];
-  ariaRequired: (value: string) => HTMLElements[TagName];
-  ariaRoledescription: (value: string) => HTMLElements[TagName];
-  ariaRowcount: (value: string) => HTMLElements[TagName];
-  ariaRowindex: (value: string) => HTMLElements[TagName];
-  ariaRowspan: (value: string) => HTMLElements[TagName];
-  ariaSelected: (value: string) => HTMLElements[TagName];
-  ariaSetsize: (value: string) => HTMLElements[TagName];
-  ariaSort: (value: string) => HTMLElements[TagName];
-  ariaValuemax: (value: string) => HTMLElements[TagName];
-  ariaValuemin: (value: string) => HTMLElements[TagName];
-  ariaValuenow: (value: string) => HTMLElements[TagName];
-  ariaValuetext: (value: string) => HTMLElements[TagName];
+export type GlobalAriaAttributes<ReturnElement> = {
+  "ariaActivedescendant": (value: string) => ReturnElement;
+  "ariaAtomic": (value: string) => ReturnElement;
+  "ariaAutocomplete": (value: string) => ReturnElement;
+  "ariaBusy": (value: string) => ReturnElement;
+  "ariaChecked": (value: string) => ReturnElement;
+  "ariaColcount": (value: string) => ReturnElement;
+  "ariaColindex": (value: string) => ReturnElement;
+  "ariaColspan": (value: string) => ReturnElement;
+  "ariaControls": (value: string) => ReturnElement;
+  "ariaCurrent": (value: string) => ReturnElement;
+  "ariaDescribedby": (value: string) => ReturnElement;
+  "ariaDetails": (value: string) => ReturnElement;
+  "ariaDisabled": (value: string) => ReturnElement;
+  "ariaDropeffect": (value: string) => ReturnElement;
+  "ariaErrormessage": (value: string) => ReturnElement;
+  "ariaExpanded": (value: string) => ReturnElement;
+  "ariaFlowto": (value: string) => ReturnElement;
+  "ariaGrabbed": (value: string) => ReturnElement;
+  "ariaHaspopup": (value: string) => ReturnElement;
+  "ariaHidden": (value: string) => ReturnElement;
+  "ariaInvalid": (value: string) => ReturnElement;
+  "ariaKeyshortcuts": (value: string) => ReturnElement;
+  "ariaLabel": (value: string) => ReturnElement;
+  "ariaLabelledby": (value: string) => ReturnElement;
+  "ariaLevel": (value: string) => ReturnElement;
+  "ariaLive": (value: string) => ReturnElement;
+  "ariaModal": (value: string) => ReturnElement;
+  "ariaMultiline": (value: string) => ReturnElement;
+  "ariaMultiselectable": (value: string) => ReturnElement;
+  "ariaOrientation": (value: string) => ReturnElement;
+  "ariaOwns": (value: string) => ReturnElement;
+  "ariaPlaceholder": (value: string) => ReturnElement;
+  "ariaPosinset": (value: string) => ReturnElement;
+  "ariaPressed": (value: string) => ReturnElement;
+  "ariaReadonly": (value: string) => ReturnElement;
+  "ariaRelevant": (value: string) => ReturnElement;
+  "ariaRequired": (value: string) => ReturnElement;
+  "ariaRoledescription": (value: string) => ReturnElement;
+  "ariaRowcount": (value: string) => ReturnElement;
+  "ariaRowindex": (value: string) => ReturnElement;
+  "ariaRowspan": (value: string) => ReturnElement;
+  "ariaSelected": (value: string) => ReturnElement;
+  "ariaSetsize": (value: string) => ReturnElement;
+  "ariaSort": (value: string) => ReturnElement;
+  "ariaValuemax": (value: string) => ReturnElement;
+  "ariaValuemin": (value: string) => ReturnElement;
+  "ariaValuenow": (value: string) => ReturnElement;
+  "ariaValuetext": (value: string) => ReturnElement;
 };
 
 type aElement = {
   /** @deprecated Hinted at the character encoding of the linked URL. Note: This attribute is deprecated and should not be used by authors. Use the HTTP Content-Type header on the linked URL. */
-  charset: (value: string) => HTMLElements["a"];
+  "charset": (value: string) => BaseHTMLElements["a"];
   /** @deprecated Used with the shape attribute. A comma-separated list of coordinates. */
-  coords: (value: string) => HTMLElements["a"];
+  "coords": (value: string) => BaseHTMLElements["a"];
   /** Prompts the user to save the linked URL instead of navigating to it. Can be used with or without a value: Without a value, the browser will suggest a filename/extension, generated from various sources: The Content-Disposition HTTP header The final segment in the URL path The media type (from the Content-Type header, the start of a data: URL, or Blob.type for a blob: URL) Defining a value suggests it as the filename. / and \ characters are converted to underscores (_). Filesystems may forbid other characters in filenames, so browsers will adjust the suggested name if necessary. Note: download only works for same-origin URLs, or the blob: and data: schemes. If the Content-Disposition header has different information from the download attribute, resulting behavior may differ: If the header specifies a filename, it takes priority over a filename specified in the download attribute. If the header specifies a disposition of inline, Chrome, and Firefox 82 and later, prioritize the attribute and treat it as a download. Firefox versions before 82 prioritize the header and will display the content inline. */
-  download: (value: string) => HTMLElements["a"];
+  "download": (value: string) => BaseHTMLElements["a"];
   /** The URL that the hyperlink points to. Links are not restricted to HTTP-based URLs — they can use any URL scheme supported by browsers: Sections of a page with fragment URLs Pieces of media files with media fragments Telephone numbers with tel: URLs Email addresses with mailto: URLs While web browsers may not support other URL schemes, web sites can with registerProtocolHandler() */
-  href: (value: string) => HTMLElements["a"];
+  "href": (value: string) => BaseHTMLElements["a"];
   /** Hints at the human language of the linked URL. No built-in functionality. Allowed values are the same as the global lang attribute. */
-  hreflang: (value: string) => HTMLElements["a"];
+  "hreflang": (value: string) => BaseHTMLElements["a"];
   /** @deprecated Was required to define a possible target location in a page. In HTML 4.01, id and name could both be used on <a>, as long as they had identical values. Note: Use the global attribute id instead. */
-  name: (value: string) => HTMLElements["a"];
+  "name": (value: string) => BaseHTMLElements["a"];
   /** A space-separated list of URLs. When the link is followed, the browser will send POST requests with the body PING to the URLs. Typically for tracking. */
-  ping: (value: string) => HTMLElements["a"];
+  "ping": (value: string) => BaseHTMLElements["a"];
   /** How much of the referrer to send when following the link. no-referrer: The Referer header will not be sent. no-referrer-when-downgrade: The Referer header will not be sent to origins without TLS (HTTPS). origin: The sent referrer will be limited to the origin of the referring page: its scheme, host, and port. origin-when-cross-origin: The referrer sent to other origins will be limited to the scheme, the host, and the port. Navigations on the same origin will still include the path. same-origin: A referrer will be sent for same origin, but cross-origin requests will contain no referrer information. strict-origin: Only send the origin of the document as the referrer when the protocol security level stays the same (HTTPS→HTTPS), but don't send it to a less secure destination (HTTPS→HTTP). strict-origin-when-cross-origin (default): Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP). unsafe-url: The referrer will include the origin and the path (but not the fragment, password, or username). This value is unsafe, because it leaks origins and paths from TLS-protected resources to insecure origins. */
-  referrerpolicy: (
-    value:
-      | ""
-      | "no-referrer"
-      | "no-referrer-when-downgrade"
-      | "same-origin"
-      | "origin"
-      | "strict-origin"
-      | "origin-when-cross-origin"
-      | "strict-origin-when-cross-origin"
-      | "unsafe-url"
-  ) => HTMLElements["a"];
+  "referrerpolicy": (value: "" | "no-referrer" | "no-referrer-when-downgrade" | "same-origin" | "origin" | "strict-origin" | "origin-when-cross-origin" | "strict-origin-when-cross-origin" | "unsafe-url") => BaseHTMLElements["a"];
   /** The relationship of the linked URL as space-separated link types. */
-  rel: (value: string) => HTMLElements["a"];
+  "rel": (value: string) => BaseHTMLElements["a"];
   /** @deprecated Specified a reverse link; the opposite of the rel attribute. Deprecated for being very confusing. */
-  rev: (value: string) => HTMLElements["a"];
-  role: (value: string) => HTMLElements["a"];
+  "rev": (value: string) => BaseHTMLElements["a"];
+  "role": (value: string) => BaseHTMLElements["a"];
   /** @deprecated The shape of the hyperlink's region in an image map. Note: Use the <area> element for image maps instead. */
-  shape: (value: string) => HTMLElements["a"];
+  "shape": (value: string) => BaseHTMLElements["a"];
   /** Where to display the linked URL, as the name for a browsing context (a tab, window, or <iframe>). The following keywords have special meanings for where to load the URL: _self: the current browsing context. (Default) _blank: usually a new tab, but users can configure browsers to open a new window instead. _parent: the parent browsing context of the current one. If no parent, behaves as _self. _top: the topmost browsing context (the "highest" context that's an ancestor of the current one). If no ancestors, behaves as _self. Note: Setting target="_blank" on <a> elements implicitly provides the same rel behavior as setting rel="noopener" which does not set window.opener. See browser compatibility for support status. */
-  target: (value: string) => HTMLElements["a"];
+  "target": (value: string) => BaseHTMLElements["a"];
   /** Hints at the linked URL's format with a MIME type. No built-in functionality. */
-  type: (value: string) => HTMLElements["a"];
-} & GlobalAriaAttributes<"a"> &
-  GlobalHTMLAttributes<"a">;
+  "type": (value: string) => BaseHTMLElements["a"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<aElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<aElement>[key] } & { (...children: children): aElement; };
 
 type abbrElement = {
-  role: (value: string) => HTMLElements["abbr"];
-} & GlobalAriaAttributes<"abbr"> &
-  GlobalHTMLAttributes<"abbr">;
+  "role": (value: string) => BaseHTMLElements["abbr"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<abbrElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<abbrElement>[key] } & { (...children: children): abbrElement; };
 
-type acronymElement = {} & GlobalAriaAttributes<"acronym"> &
-  GlobalHTMLAttributes<"acronym">;
+type acronymElement = {
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<acronymElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<acronymElement>[key] } & { (...children: children): acronymElement; };
 
 type addressElement = {
-  role: (value: string) => HTMLElements["address"];
-} & GlobalAriaAttributes<"address"> &
-  GlobalHTMLAttributes<"address">;
+  "role": (value: string) => BaseHTMLElements["address"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<addressElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<addressElement>[key] } & { (...children: children): addressElement; };
 
 type appletElement = {
   /** This attribute is used to position the applet on the page relative to content that might flow around it. The HTML 4.01 specification defines values of bottom, left, middle, right, and top, whereas Microsoft and Netscape also might support absbottom, absmiddle, baseline, center, and texttop. */
-  align: (value: string) => HTMLElements["applet"];
+  "align": (value: string) => BaseHTMLElements["applet"];
   /** This attribute causes a descriptive text alternate to be displayed on browsers that do not support Java. Page designers should also remember that content enclosed within the <applet> element may also be rendered as alternative text. */
-  alt: (value: string) => HTMLElements["applet"];
+  "alt": (value: string) => BaseHTMLElements["applet"];
   /** This attribute refers to an archived or compressed version of the applet and its associated class files, which might help reduce download time. */
-  archive: (value: string) => HTMLElements["applet"];
+  "archive": (value: string) => BaseHTMLElements["applet"];
   /** This attribute specifies the URL of the applet's class file to be loaded and executed. Applet filenames are identified by a .class filename extension. The URL specified by code might be relative to the codebase attribute. */
-  code: (value: string) => HTMLElements["applet"];
+  "code": (value: string) => BaseHTMLElements["applet"];
   /** This attribute gives the absolute or relative URL of the directory where applets' .class files referenced by the code attribute are stored. */
-  codebase: (value: string) => HTMLElements["applet"];
+  "codebase": (value: string) => BaseHTMLElements["applet"];
   /** This attribute, supported by Internet Explorer 4 and higher, specifies the column name from the data source object that supplies the bound data. This attribute might be used to specify the various <param> elements passed to the Java applet. */
-  datafld: (value: string) => HTMLElements["applet"];
+  "datafld": (value: string) => BaseHTMLElements["applet"];
   /** Like datafld, this attribute is used for data binding under Internet Explorer 4. It indicates the id of the data source object that supplies the data that is bound to the <param> elements associated with the applet. */
-  datasrc: (value: string) => HTMLElements["applet"];
+  "datasrc": (value: string) => BaseHTMLElements["applet"];
   /** This attribute specifies the height, in pixels, that the applet needs. */
-  height: (value: string) => HTMLElements["applet"];
+  "height": (value: string) => BaseHTMLElements["applet"];
   /** This attribute specifies additional horizontal space, in pixels, to be reserved on either side of the applet. */
-  hspace: (value: string) => HTMLElements["applet"];
+  "hspace": (value: string) => BaseHTMLElements["applet"];
   /** In the Netscape implementation, this attribute allows access to an applet by programs in a scripting language embedded in the document. */
-  mayscript: (value: string) => HTMLElements["applet"];
+  "mayscript": (value: string) => BaseHTMLElements["applet"];
   /** This attribute assigns a name to the applet so that it can be identified by other resources; particularly scripts. */
-  name: (value: string) => HTMLElements["applet"];
+  "name": (value: string) => BaseHTMLElements["applet"];
   /** This attribute specifies the URL of a serialized representation of an applet. */
-  object: (value: string) => HTMLElements["applet"];
+  "object": (value: string) => BaseHTMLElements["applet"];
   /** As defined for Internet Explorer 4 and higher, this attribute specifies a URL for an associated file for the applet. The meaning and use is unclear and not part of the HTML standard. */
-  src: (value: string) => HTMLElements["applet"];
+  "src": (value: string) => BaseHTMLElements["applet"];
   /** This attribute specifies additional vertical space, in pixels, to be reserved above and below the applet. */
-  vspace: (value: string) => HTMLElements["applet"];
+  "vspace": (value: string) => BaseHTMLElements["applet"];
   /** This attribute specifies in pixels the width that the applet needs. */
-  width: (value: string) => HTMLElements["applet"];
-} & GlobalAriaAttributes<"applet"> &
-  GlobalHTMLAttributes<"applet">;
+  "width": (value: string) => BaseHTMLElements["applet"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<appletElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<appletElement>[key] } & { (...children: children): appletElement; };
 
 type areaElement = {
-  alt: (value: string) => HTMLElements["area"];
-  coords: (value: string) => HTMLElements["area"];
+  "alt": (value: string) => BaseHTMLElements["area"];
+  "coords": (value: string) => BaseHTMLElements["area"];
   /** This attribute, if present, indicates that the author intends the hyperlink to be used for downloading a resource. See <a> for a full description of the download attribute. */
-  download: (value: string) => HTMLElements["area"];
+  "download": (value: string) => BaseHTMLElements["area"];
   /** The hyperlink target for the area. Its value is a valid URL. This attribute may be omitted; if so, the <area> element does not represent a hyperlink. */
-  href: (value: string) => HTMLElements["area"];
+  "href": (value: string) => BaseHTMLElements["area"];
   /** Indicates the language of the linked resource. Allowed values are defined by RFC 5646: Tags for Identifying Languages (also known as BCP 47). Use this attribute only if the href attribute is present. */
-  hreflang: (value: string) => HTMLElements["area"];
+  "hreflang": (value: string) => BaseHTMLElements["area"];
   /** @deprecated Define a names for the clickable area so that it can be scripted by older browsers. */
-  name: (value: string) => HTMLElements["area"];
+  "name": (value: string) => BaseHTMLElements["area"];
   /** @deprecated Indicates that no hyperlink exists for the associated area. Note: Since HTML5, omitting the href attribute is sufficient. */
-  nohref: (value: string) => HTMLElements["area"];
+  "nohref": (value: string) => BaseHTMLElements["area"];
   /** Contains a space-separated list of URLs to which, when the hyperlink is followed, POST requests with the body PING will be sent by the browser (in the background). Typically used for tracking. */
-  ping: (value: string) => HTMLElements["area"];
+  "ping": (value: string) => BaseHTMLElements["area"];
   /** A string indicating which referrer to use when fetching the resource: no-referrer: The Referer header will not be sent. no-referrer-when-downgrade: The Referer header will not be sent to origins without TLS (HTTPS). origin: The sent referrer will be limited to the origin of the referring page: its scheme, host, and port. origin-when-cross-origin: The referrer sent to other origins will be limited to the scheme, the host, and the port. Navigations on the same origin will still include the path. same-origin: A referrer will be sent for same origin, but cross-origin requests will contain no referrer information. strict-origin: Only send the origin of the document as the referrer when the protocol security level stays the same (HTTPS→HTTPS), but don't send it to a less secure destination (HTTPS→HTTP). strict-origin-when-cross-origin (default): Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP). unsafe-url: The referrer will include the origin and the path (but not the fragment, password, or username). This value is unsafe, because it leaks origins and paths from TLS-protected resources to insecure origins. */
-  referrerpolicy: (
-    value:
-      | ""
-      | "no-referrer"
-      | "no-referrer-when-downgrade"
-      | "same-origin"
-      | "origin"
-      | "strict-origin"
-      | "origin-when-cross-origin"
-      | "strict-origin-when-cross-origin"
-      | "unsafe-url"
-  ) => HTMLElements["area"];
+  "referrerpolicy": (value: "" | "no-referrer" | "no-referrer-when-downgrade" | "same-origin" | "origin" | "strict-origin" | "origin-when-cross-origin" | "strict-origin-when-cross-origin" | "unsafe-url") => BaseHTMLElements["area"];
   /** For anchors containing the href attribute, this attribute specifies the relationship of the target object to the link object. The value is a space-separated list of link types values. The values and their semantics will be registered by some authority that might have meaning to the document author. The default relationship, if no other is given, is void. Use this attribute only if the href attribute is present. */
-  rel: (value: string) => HTMLElements["area"];
-  role: (value: string) => HTMLElements["area"];
-  shape: (
-    value: "rect" | "circle" | "poly" | "default"
-  ) => HTMLElements["area"];
+  "rel": (value: string) => BaseHTMLElements["area"];
+  "role": (value: string) => BaseHTMLElements["area"];
+  "shape": (value: "rect" | "circle" | "poly" | "default") => BaseHTMLElements["area"];
   /** A keyword or author-defined name of the browsing context to display the linked resource. The following keywords have special meanings: _self (default): Show the resource in the current browsing context. _blank: Show the resource in a new, unnamed browsing context. _parent: Show the resource in the parent browsing context of the current one, if the current page is inside a frame. If there is no parent, acts the same as _self. _top: Show the resource in the topmost browsing context (the browsing context that is an ancestor of the current one and has no parent). If there is no parent, acts the same as _self. Use this attribute only if the href attribute is present. Note: Setting target="_blank" on <area> elements implicitly provides the same rel behavior as setting rel="noopener" which does not set window.opener. See browser compatibility for support status. */
-  target: (value: string) => HTMLElements["area"];
+  "target": (value: string) => BaseHTMLElements["area"];
   /** @deprecated Hint for the type of the referenced resource. Ignored by browsers. */
-  type: (value: string) => HTMLElements["area"];
-} & GlobalAriaAttributes<"area"> &
-  GlobalHTMLAttributes<"area">;
+  "type": (value: string) => BaseHTMLElements["area"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<areaElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<areaElement>[key] } & { (...children: children): areaElement; };
 
 type articleElement = {
-  role: (value: string) => HTMLElements["article"];
-} & GlobalAriaAttributes<"article"> &
-  GlobalHTMLAttributes<"article">;
+  "role": (value: string) => BaseHTMLElements["article"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<articleElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<articleElement>[key] } & { (...children: children): articleElement; };
 
 type asideElement = {
-  role: (value: string) => HTMLElements["aside"];
-} & GlobalAriaAttributes<"aside"> &
-  GlobalHTMLAttributes<"aside">;
+  "role": (value: string) => BaseHTMLElements["aside"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<asideElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<asideElement>[key] } & { (...children: children): asideElement; };
 
 type audioElement = {
   /** A Boolean attribute: if specified, the audio will automatically begin playback as soon as it can do so, without waiting for the entire audio file to finish downloading. Note: Sites that automatically play audio (or videos with an audio track) can be an unpleasant experience for users, so should be avoided when possible. If you must offer autoplay functionality, you should make it opt-in (requiring a user to specifically enable it). However, this can be useful when creating media elements whose source will be set at a later time, under user control. See our autoplay guide for additional information about how to properly use autoplay. */
-  autoplay: (value: boolean) => HTMLElements["audio"];
+  "autoplay": (value: boolean) => BaseHTMLElements["audio"];
   /** If this attribute is present, the browser will offer controls to allow the user to control audio playback, including volume, seeking, and pause/resume playback. */
-  controls: (value: boolean) => HTMLElements["audio"];
+  "controls": (value: boolean) => BaseHTMLElements["audio"];
   /** This enumerated attribute indicates whether to use CORS to fetch the related audio file. CORS-enabled resources can be reused in the <canvas> element without being tainted. The allowed values are: anonymous Sends a cross-origin request without a credential. In other words, it sends the Origin: HTTP header without a cookie, X.509 certificate, or performing HTTP Basic authentication. If the server does not give credentials to the origin site (by not setting the Access-Control-Allow-Origin: HTTP header), the image will be tainted, and its usage restricted. use-credentials Sends a cross-origin request with a credential. In other words, it sends the Origin: HTTP header with a cookie, a certificate, or performing HTTP Basic authentication. If the server does not give credentials to the origin site (through Access-Control-Allow-Credentials: HTTP header), the image will be tainted and its usage restricted. When not present, the resource is fetched without a CORS request (i.e. without sending the Origin: HTTP header), preventing its non-tainted used in <canvas> elements. If invalid, it is handled as if the enumerated keyword anonymous was used. See CORS settings attributes for additional information. */
-  crossorigin: (
-    value: "" | "anonymous" | "use-credentials"
-  ) => HTMLElements["audio"];
+  "crossorigin": (value: "" | "anonymous" | "use-credentials") => BaseHTMLElements["audio"];
   /** A Boolean attribute used to disable the capability of remote playback in devices that are attached using wired (HDMI, DVI, etc.) and wireless technologies (Miracast, Chromecast, DLNA, AirPlay, etc). See this proposed specification for more information. Note: In Safari, you can use x-webkit-airplay="deny" as a fallback. */
-  disableremoteplayback: (value: string) => HTMLElements["audio"];
+  "disableremoteplayback": (value: string) => BaseHTMLElements["audio"];
   /** A Boolean attribute: if specified, the audio player will automatically seek back to the start upon reaching the end of the audio. */
-  loop: (value: boolean) => HTMLElements["audio"];
+  "loop": (value: boolean) => BaseHTMLElements["audio"];
   /** A Boolean attribute that indicates whether the audio will be initially silenced. Its default value is false. */
-  muted: (value: boolean) => HTMLElements["audio"];
+  "muted": (value: boolean) => BaseHTMLElements["audio"];
   /** This enumerated attribute is intended to provide a hint to the browser about what the author thinks will lead to the best user experience. It may have one of the following values: none: Indicates that the audio should not be preloaded. metadata: Indicates that only audio metadata (e.g. length) is fetched. auto: Indicates that the whole audio file can be downloaded, even if the user is not expected to use it. empty string: A synonym of the auto value. The default value is different for each browser. The spec advises it to be set to metadata. Note: The autoplay attribute has precedence over preload. If autoplay is specified, the browser would obviously need to start downloading the audio for playback. The browser is not forced by the specification to follow the value of this attribute; it is a mere hint. */
-  preload: (value: "none" | "metadata" | "auto") => HTMLElements["audio"];
-  role: (value: string) => HTMLElements["audio"];
+  "preload": (value: "none" | "metadata" | "auto") => BaseHTMLElements["audio"];
+  "role": (value: string) => BaseHTMLElements["audio"];
   /** The URL of the audio to embed. This is subject to HTTP access controls. This is optional; you may instead use the <source> element within the audio block to specify the audio to embed. */
-  src: (value: string) => HTMLElements["audio"];
-} & GlobalAriaAttributes<"audio"> &
-  GlobalHTMLAttributes<"audio">;
+  "src": (value: string) => BaseHTMLElements["audio"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<audioElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<audioElement>[key] } & { (...children: children): audioElement; };
 
 type bElement = {
-  role: (value: string) => HTMLElements["b"];
-} & GlobalAriaAttributes<"b"> &
-  GlobalHTMLAttributes<"b">;
+  "role": (value: string) => BaseHTMLElements["b"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<bElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<bElement>[key] } & { (...children: children): bElement; };
 
 type baseElement = {
   /** The base URL to be used throughout the document for relative URLs. Absolute and relative URLs are allowed. */
-  href: (value: string) => HTMLElements["base"];
-  role: (value: string) => HTMLElements["base"];
+  "href": (value: string) => BaseHTMLElements["base"];
+  "role": (value: string) => BaseHTMLElements["base"];
   /** A keyword or author-defined name of the default browsing context to show the results of navigation from <a>, <area>, or <form> elements without explicit target attributes. The following keywords have special meanings: _self (default): Show the result in the current browsing context. _blank: Show the result in a new, unnamed browsing context. _parent: Show the result in the parent browsing context of the current one, if the current page is inside a frame. If there is no parent, acts the same as _self. _top: Show the result in the topmost browsing context (the browsing context that is an ancestor of the current one and has no parent). If there is no parent, acts the same as _self. */
-  target: (value: string) => HTMLElements["base"];
-} & GlobalAriaAttributes<"base"> &
-  GlobalHTMLAttributes<"base">;
+  "target": (value: string) => BaseHTMLElements["base"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<baseElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<baseElement>[key] } & { (...children: children): baseElement; };
 
 type basefontElement = {
   /** This attribute sets the text color using either a named color or a color specified in the hexadecimal #RRGGBB format. */
-  color: (value: string) => HTMLElements["basefont"];
+  "color": (value: string) => BaseHTMLElements["basefont"];
   /** This attribute contains a list of one or more font names. The document text in the default style is rendered in the first font face that the client's browser supports. If no font listed is installed on the local system, the browser typically defaults to the proportional or fixed-width font for that system. */
-  face: (value: string) => HTMLElements["basefont"];
+  "face": (value: string) => BaseHTMLElements["basefont"];
   /** This attribute specifies the font size as either a numeric or relative value. Numeric values range from 1 to 7 with 1 being the smallest and 3 the default. */
-  size: (value: string) => HTMLElements["basefont"];
-} & GlobalAriaAttributes<"basefont"> &
-  GlobalHTMLAttributes<"basefont">;
+  "size": (value: string) => BaseHTMLElements["basefont"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<basefontElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<basefontElement>[key] } & { (...children: children): basefontElement; };
 
 type bdiElement = {
-  role: (value: string) => HTMLElements["bdi"];
-} & GlobalAriaAttributes<"bdi"> &
-  GlobalHTMLAttributes<"bdi">;
+  "role": (value: string) => BaseHTMLElements["bdi"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<bdiElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<bdiElement>[key] } & { (...children: children): bdiElement; };
 
 type bdoElement = {
-  role: (value: string) => HTMLElements["bdo"];
-} & GlobalAriaAttributes<"bdo"> &
-  GlobalHTMLAttributes<"bdo">;
+  "role": (value: string) => BaseHTMLElements["bdo"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<bdoElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<bdoElement>[key] } & { (...children: children): bdoElement; };
 
 type bgsoundElement = {
   /** This attribute defines a number between -10,000 and +10,000 that determines how the volume will be divided between the speakers. */
-  balance: (value: string) => HTMLElements["bgsound"];
+  "balance": (value: string) => BaseHTMLElements["bgsound"];
   /** This attribute indicates the number of times a sound is to be played and either has a numeric value or the keyword infinite. */
-  loop: (value: string) => HTMLElements["bgsound"];
+  "loop": (value: string) => BaseHTMLElements["bgsound"];
   /** This attribute specifies the URL of the sound file to be played, which must be one of the following types: .wav, .au, or .mid. */
-  src: (value: string) => HTMLElements["bgsound"];
+  "src": (value: string) => BaseHTMLElements["bgsound"];
   /** This attribute defines a number between -10,000 and 0 that determines the loudness of a page's background sound. */
-  volume: (value: string) => HTMLElements["bgsound"];
-} & GlobalAriaAttributes<"bgsound"> &
-  GlobalHTMLAttributes<"bgsound">;
+  "volume": (value: string) => BaseHTMLElements["bgsound"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<bgsoundElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<bgsoundElement>[key] } & { (...children: children): bgsoundElement; };
 
-type bigElement = {} & GlobalAriaAttributes<"big"> &
-  GlobalHTMLAttributes<"big">;
+type bigElement = {
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<bigElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<bigElement>[key] } & { (...children: children): bigElement; };
 
-type blinkElement = {} & GlobalAriaAttributes<"blink"> &
-  GlobalHTMLAttributes<"blink">;
+type blinkElement = {
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<blinkElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<blinkElement>[key] } & { (...children: children): blinkElement; };
 
 type blockquoteElement = {
-  cite: (value: string) => HTMLElements["blockquote"];
-  role: (value: string) => HTMLElements["blockquote"];
-} & GlobalAriaAttributes<"blockquote"> &
-  GlobalHTMLAttributes<"blockquote">;
+  "cite": (value: string) => BaseHTMLElements["blockquote"];
+  "role": (value: string) => BaseHTMLElements["blockquote"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<blockquoteElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<blockquoteElement>[key] } & { (...children: children): blockquoteElement; };
 
 type bodyElement = {
   /** @deprecated Color of text for hyperlinks when selected. This method is non-conforming, use CSS color property in conjunction with the :active pseudo-class instead. */
-  alink: (value: string) => HTMLElements["body"];
+  "alink": (value: string) => BaseHTMLElements["body"];
   /** @deprecated URI of a image to use as a background. This method is non-conforming, use CSS background property on the element instead. */
-  background: (value: string) => HTMLElements["body"];
+  "background": (value: string) => BaseHTMLElements["body"];
   /** @deprecated Background color for the document. This method is non-conforming, use CSS background-color property on the element instead. */
-  bgcolor: (value: string) => HTMLElements["body"];
+  "bgcolor": (value: string) => BaseHTMLElements["body"];
   /** @deprecated The margin of the bottom of the body. This method is non-conforming, use CSS margin-bottom property on the element instead. */
-  bottommargin: (value: string) => HTMLElements["body"];
+  "bottommargin": (value: string) => BaseHTMLElements["body"];
   /** @deprecated The margin of the left of the body. This method is non-conforming, use CSS margin-left property on the element instead. */
-  leftmargin: (value: string) => HTMLElements["body"];
+  "leftmargin": (value: string) => BaseHTMLElements["body"];
   /** @deprecated Color of text for unvisited hypertext links. This method is non-conforming, use CSS color property in conjunction with the :link pseudo-class instead. */
-  link: (value: string) => HTMLElements["body"];
+  "link": (value: string) => BaseHTMLElements["body"];
   /** Function to call when the user has moved forward in undo transaction history. */
-  onredo: (value: string) => HTMLElements["body"];
+  "onredo": (value: string) => BaseHTMLElements["body"];
   /** Function to call when the user has moved backward in undo transaction history. */
-  onundo: (value: string) => HTMLElements["body"];
+  "onundo": (value: string) => BaseHTMLElements["body"];
   /** @deprecated The margin of the right of the body. This method is non-conforming, use CSS margin-right property on the element instead. */
-  rightmargin: (value: string) => HTMLElements["body"];
-  role: (value: string) => HTMLElements["body"];
+  "rightmargin": (value: string) => BaseHTMLElements["body"];
+  "role": (value: string) => BaseHTMLElements["body"];
   /** @deprecated Foreground color of text. This method is non-conforming, use CSS color property on the element instead. */
-  text: (value: string) => HTMLElements["body"];
+  "text": (value: string) => BaseHTMLElements["body"];
   /** @deprecated The margin of the top of the body. This method is non-conforming, use CSS margin-top property on the element instead. */
-  topmargin: (value: string) => HTMLElements["body"];
+  "topmargin": (value: string) => BaseHTMLElements["body"];
   /** @deprecated Color of text for visited hypertext links. This method is non-conforming, use CSS color property in conjunction with the :visited pseudo-class instead. */
-  vlink: (value: string) => HTMLElements["body"];
-} & GlobalAriaAttributes<"body"> &
-  GlobalHTMLAttributes<"body">;
+  "vlink": (value: string) => BaseHTMLElements["body"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<bodyElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<bodyElement>[key] } & { (...children: children): bodyElement; };
 
 type brElement = {
   /** @deprecated Indicates where to begin the next line after the break. */
-  clear: (value: string) => HTMLElements["br"];
-  role: (value: string) => HTMLElements["br"];
-} & GlobalAriaAttributes<"br"> &
-  GlobalHTMLAttributes<"br">;
+  "clear": (value: string) => BaseHTMLElements["br"];
+  "role": (value: string) => BaseHTMLElements["br"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<brElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<brElement>[key] } & { (...children: children): brElement; };
 
 type buttonElement = {
   /** This attribute on a <button> is nonstandard and Firefox-specific. Unlike other browsers, Firefox persists the dynamic disabled state of a <button> across page loads. Setting autocomplete="off" on the button disables this feature; see bug 654072. */
-  autocomplete: (value: string) => HTMLElements["button"];
+  "autocomplete": (value: string) => BaseHTMLElements["button"];
   /** This Boolean attribute prevents the user from interacting with the button: it cannot be pressed or focused. Firefox, unlike other browsers, persists the dynamic disabled state of a <button> across page loads. Use the autocomplete attribute to control this feature. */
-  disabled: (value: boolean) => HTMLElements["button"];
+  "disabled": (value: boolean) => BaseHTMLElements["button"];
   /** The <form> element to associate the button with (its form owner). The value of this attribute must be the id of a <form> in the same document. (If this attribute is not set, the <button> is associated with its ancestor <form> element, if any.) This attribute lets you associate <button> elements to <form>s anywhere in the document, not just inside a <form>. It can also override an ancestor <form> element. */
-  form: (value: string) => HTMLElements["button"];
+  "form": (value: string) => BaseHTMLElements["button"];
   /** The URL that processes the information submitted by the button. Overrides the action attribute of the button's form owner. Does nothing if there is no form owner. */
-  formaction: (value: string) => HTMLElements["button"];
+  "formaction": (value: string) => BaseHTMLElements["button"];
   /** If the button is a submit button (it's inside/associated with a <form> and doesn't have type="button"), specifies how to encode the form data that is submitted. Possible values: application/x-www-form-urlencoded: The default if the attribute is not used. multipart/form-data: Use to submit <input> elements with their type attributes set to file. text/plain: Specified as a debugging aid; shouldn't be used for real form submission. If this attribute is specified, it overrides the enctype attribute of the button's form owner. */
-  formenctype: (
-    value:
-      | "application/x-www-form-urlencoded"
-      | "multipart/form-data"
-      | "text/plain"
-  ) => HTMLElements["button"];
+  "formenctype": (value: "application/x-www-form-urlencoded" | "multipart/form-data" | "text/plain") => BaseHTMLElements["button"];
   /** If the button is a submit button (it's inside/associated with a <form> and doesn't have type="button"), this attribute specifies the HTTP method used to submit the form. Possible values: post: The data from the form are included in the body of the HTTP request when sent to the server. Use when the form contains information that shouldn't be public, like login credentials. get: The form data are appended to the form's action URL, with a ? as a separator, and the resulting URL is sent to the server. Use this method when the form has no side effects, like search forms. If specified, this attribute overrides the method attribute of the button's form owner. */
-  formmethod: (value: "post" | "get" | "dialog") => HTMLElements["button"];
+  "formmethod": (value: "post" | "get" | "dialog") => BaseHTMLElements["button"];
   /** If the button is a submit button, this Boolean attribute specifies that the form is not to be validated when it is submitted. If this attribute is specified, it overrides the novalidate attribute of the button's form owner. This attribute is also available on <input type="image"> and <input type="submit"> elements. */
-  formnovalidate: (value: boolean) => HTMLElements["button"];
+  "formnovalidate": (value: boolean) => BaseHTMLElements["button"];
   /** If the button is a submit button, this attribute is an author-defined name or standardized, underscore-prefixed keyword indicating where to display the response from submitting the form. This is the name of, or keyword for, a browsing context (a tab, window, or <iframe>). If this attribute is specified, it overrides the target attribute of the button's form owner. The following keywords have special meanings: _self: Load the response into the same browsing context as the current one. This is the default if the attribute is not specified. _blank: Load the response into a new unnamed browsing context — usually a new tab or window, depending on the user's browser settings. _parent: Load the response into the parent browsing context of the current one. If there is no parent, this option behaves the same way as _self. _top: Load the response into the top-level browsing context (that is, the browsing context that is an ancestor of the current one, and has no parent). If there is no parent, this option behaves the same way as _self. */
-  formtarget: (value: string) => HTMLElements["button"];
+  "formtarget": (value: string) => BaseHTMLElements["button"];
   /** The name of the button, submitted as a pair with the button's value as part of the form data, when that button is used to submit the form. */
-  name: (value: string) => HTMLElements["button"];
-  role: (value: string) => HTMLElements["button"];
-  type: (value: "submit" | "reset" | "button") => HTMLElements["button"];
-  value: (value: string) => HTMLElements["button"];
-} & GlobalAriaAttributes<"button"> &
-  GlobalHTMLAttributes<"button">;
+  "name": (value: string) => BaseHTMLElements["button"];
+  "role": (value: string) => BaseHTMLElements["button"];
+  "type": (value: "submit" | "reset" | "button") => BaseHTMLElements["button"];
+  "value": (value: string) => BaseHTMLElements["button"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<buttonElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<buttonElement>[key] } & { (...children: children): buttonElement; };
 
 type canvasElement = {
-  height: (value: number) => HTMLElements["canvas"];
+  "height": (value: number) => BaseHTMLElements["canvas"];
   /** @deprecated Lets the canvas know whether or not translucency will be a factor. If the canvas knows there's no translucency, painting performance can be optimized. This is only supported by Mozilla-based browsers; use the standardized canvas.getContext('2d', { alpha: false }) instead. */
-  mozOpaque: (value: string) => HTMLElements["canvas"];
-  role: (value: string) => HTMLElements["canvas"];
-  width: (value: number) => HTMLElements["canvas"];
-} & GlobalAriaAttributes<"canvas"> &
-  GlobalHTMLAttributes<"canvas">;
+  "mozOpaque": (value: string) => BaseHTMLElements["canvas"];
+  "role": (value: string) => BaseHTMLElements["canvas"];
+  "width": (value: number) => BaseHTMLElements["canvas"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<canvasElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<canvasElement>[key] } & { (...children: children): canvasElement; };
 
 type captionElement = {
   /** @deprecated This enumerated attribute indicates how the caption must be aligned with respect to the table. It may have one of the following values: left The caption is displayed to the left of the table. top The caption is displayed above the table. right The caption is displayed to the right of the table. bottom The caption is displayed below the table. Warning: Do not use this attribute, as it has been deprecated. The <caption> element should be styled using the CSS properties caption-side and text-align. */
-  align: (value: string) => HTMLElements["caption"];
-  role: (value: string) => HTMLElements["caption"];
-} & GlobalAriaAttributes<"caption"> &
-  GlobalHTMLAttributes<"caption">;
+  "align": (value: string) => BaseHTMLElements["caption"];
+  "role": (value: string) => BaseHTMLElements["caption"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<captionElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<captionElement>[key] } & { (...children: children): captionElement; };
 
-type centerElement = {} & GlobalAriaAttributes<"center"> &
-  GlobalHTMLAttributes<"center">;
+type centerElement = {
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<centerElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<centerElement>[key] } & { (...children: children): centerElement; };
 
 type citeElement = {
-  role: (value: string) => HTMLElements["cite"];
-} & GlobalAriaAttributes<"cite"> &
-  GlobalHTMLAttributes<"cite">;
+  "role": (value: string) => BaseHTMLElements["cite"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<citeElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<citeElement>[key] } & { (...children: children): citeElement; };
 
 type codeElement = {
-  role: (value: string) => HTMLElements["code"];
-} & GlobalAriaAttributes<"code"> &
-  GlobalHTMLAttributes<"code">;
+  "role": (value: string) => BaseHTMLElements["code"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<codeElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<codeElement>[key] } & { (...children: children): codeElement; };
 
 type colElement = {
   /** @deprecated This enumerated attribute specifies how horizontal alignment of each column cell content will be handled. Possible values are: left, aligning the content to the left of the cell center, centering the content in the cell right, aligning the content to the right of the cell justify, inserting spaces into the textual content so that the content is justified in the cell If this attribute is not set, its value is inherited from the align of the <colgroup> element this <col> element belongs too. If there are none, the left value is assumed. Note: To achieve the same effect as the left, center, right or justify values, do not try to set the text-align property on a selector giving a <col> element. Because <td> elements are not descendant of the <col> element, they won't inherit it. If the table doesn't use a colspan attribute, use the td:nth-child(an+b) CSS selector. Set a to zero and b to the position of the column in the table, e.g. td:nth-child(2) { text-align: right; } to right-align the second column. If the table does use a colspan attribute, the effect can be achieved by combining adequate CSS attribute selectors like [colspan=n], though this is not trivial. */
-  align: (value: string) => HTMLElements["col"];
+  "align": (value: string) => BaseHTMLElements["col"];
   /** @deprecated The background color of the table. It is a 6-digit hexadecimal RGB code, prefixed by a '#'. One of the predefined color keywords can also be used. To achieve a similar effect, use the CSS background-color property. */
-  bgcolor: (value: string) => HTMLElements["col"];
+  "bgcolor": (value: string) => BaseHTMLElements["col"];
   /** @deprecated This attribute is used to set the character to align the cells in a column on. Typical values for this include a period (.) when attempting to align numbers or monetary values. If align is not set to char, this attribute is ignored. */
-  char: (value: string) => HTMLElements["col"];
+  "char": (value: string) => BaseHTMLElements["col"];
   /** @deprecated This attribute is used to indicate the number of characters to offset the column data from the alignment characters specified by the char attribute. */
-  charoff: (value: string) => HTMLElements["col"];
-  role: (value: string) => HTMLElements["col"];
-  span: (value: string) => HTMLElements["col"];
+  "charoff": (value: string) => BaseHTMLElements["col"];
+  "role": (value: string) => BaseHTMLElements["col"];
+  "span": (value: string) => BaseHTMLElements["col"];
   /** @deprecated This attribute specifies the vertical alignment of the text within each cell of the column. Possible values for this attribute are: baseline, which will put the text as close to the bottom of the cell as it is possible, but align it on the baseline of the characters instead of the bottom of them. If characters are all of the size, this has the same effect as bottom. bottom, which will put the text as close to the bottom of the cell as it is possible; middle, which will center the text in the cell; and top, which will put the text as close to the top of the cell as it is possible. Note: Do not try to set the vertical-align property on a selector giving a <col> element. Because <td> elements are not descendant of the <col> element, they won't inherit it. If the table doesn't use a colspan attribute, use the td:nth-child(an+b) CSS selector where a is the total number of the columns in the table and b is the ordinal position of the column in the table. Only after this selector the vertical-align property can be used. If the table does use a colspan attribute, the effect can be achieved by combining adequate CSS attribute selectors like [colspan=n], though this is not trivial. */
-  valign: (value: string) => HTMLElements["col"];
+  "valign": (value: string) => BaseHTMLElements["col"];
   /** @deprecated This attribute specifies a default width for each column in the current column group. In addition to the standard pixel and percentage values, this attribute might take the special form 0*, which means that the width of each column in the group should be the minimum width necessary to hold the column's contents. Relative widths such as 5* also can be used. */
-  width: (value: string) => HTMLElements["col"];
-} & GlobalAriaAttributes<"col"> &
-  GlobalHTMLAttributes<"col">;
+  "width": (value: string) => BaseHTMLElements["col"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<colElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<colElement>[key] } & { (...children: children): colElement; };
 
 type colgroupElement = {
   /** @deprecated This enumerated attribute specifies how horizontal alignment of each column cell content will be handled. Possible values are: left, aligning the content to the left of the cell center, centering the content in the cell right, aligning the content to the right of the cell justify, inserting spaces into the textual content so that the content is justified in the cell char, aligning the textual content on a special character with a minimal offset, defined by the char and charoff attributes. If this attribute is not set, the left value is assumed. The descendant <col> elements may override this value using their own align attribute. Note: Do not try to set the text-align property on a selector giving a <colgroup> element. Because <td> elements are not descendant of the <colgroup> element, they won't inherit it. If the table doesn't use a colspan attribute, use one td:nth-child(an+b) CSS selector per column, where a is the total number of the columns in the table and b is the ordinal position of this column in the table. Only after this selector the text-align property can be used. If the table does use a colspan attribute, the effect can be achieved by combining adequate CSS attribute selectors like [colspan=n], though this is not trivial. */
-  align: (value: string) => HTMLElements["colgroup"];
+  "align": (value: string) => BaseHTMLElements["colgroup"];
   /** @deprecated The background color of the table. It is a 6-digit hexadecimal RGB code, prefixed by a '#'. One of the predefined color keywords can also be used. To achieve a similar effect, use the CSS background-color property. */
-  bgcolor: (value: string) => HTMLElements["colgroup"];
+  "bgcolor": (value: string) => BaseHTMLElements["colgroup"];
   /** @deprecated This attribute specifies the alignment of the content in a column group to a character. Typical values for this include a period (.) when attempting to align numbers or monetary values. If align is not set to char, this attribute is ignored, though it will still be used as the default value for the align of the <col> which are members of this column group. */
-  char: (value: string) => HTMLElements["colgroup"];
+  "char": (value: string) => BaseHTMLElements["colgroup"];
   /** @deprecated This attribute is used to indicate the number of characters to offset the column data from the alignment character specified by the char attribute. */
-  charoff: (value: string) => HTMLElements["colgroup"];
-  role: (value: string) => HTMLElements["colgroup"];
-  span: (value: string) => HTMLElements["colgroup"];
+  "charoff": (value: string) => BaseHTMLElements["colgroup"];
+  "role": (value: string) => BaseHTMLElements["colgroup"];
+  "span": (value: string) => BaseHTMLElements["colgroup"];
   /** @deprecated This attribute specifies the vertical alignment of the text within each cell of the column. Possible values for this attribute are: baseline, which will put the text as close to the bottom of the cell as it is possible, but align it on the baseline of the characters instead of the bottom of them. If characters are all of the size, this has the same effect as bottom. bottom, which will put the text as close to the bottom of the cell as it is possible; middle, which will center the text in the cell; and top, which will put the text as close to the top of the cell as it is possible. Note: Do not try to set the vertical-align property on a selector giving a <colgroup> element. Because <td> elements are not descendant of the <colgroup> element, they won't inherit it. If the table doesn't use a colspan attribute, use the td:nth-child(an+b) CSS selector per column, where a is the total number of the columns in the table and b is the ordinal position of the column in the table. Only after this selector the vertical-align property can be used. If the table does use a colspan attribute, the effect can be achieved by combining adequate CSS attribute selectors like [colspan=n], though this is not trivial. */
-  valign: (value: string) => HTMLElements["colgroup"];
-} & GlobalAriaAttributes<"colgroup"> &
-  GlobalHTMLAttributes<"colgroup">;
+  "valign": (value: string) => BaseHTMLElements["colgroup"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<colgroupElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<colgroupElement>[key] } & { (...children: children): colgroupElement; };
 
 type contentElement = {
   /** A comma-separated list of selectors. These have the same syntax as CSS selectors. They select the content to insert in place of the <content> element. */
-  select: (value: string) => HTMLElements["content"];
-} & GlobalAriaAttributes<"content"> &
-  GlobalHTMLAttributes<"content">;
+  "select": (value: string) => BaseHTMLElements["content"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<contentElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<contentElement>[key] } & { (...children: children): contentElement; };
 
 type dataElement = {
-  role: (value: string) => HTMLElements["data"];
-  value: (value: string) => HTMLElements["data"];
-} & GlobalAriaAttributes<"data"> &
-  GlobalHTMLAttributes<"data">;
+  "role": (value: string) => BaseHTMLElements["data"];
+  "value": (value: string) => BaseHTMLElements["data"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<dataElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<dataElement>[key] } & { (...children: children): dataElement; };
 
 type datalistElement = {
-  role: (value: string) => HTMLElements["datalist"];
-} & GlobalAriaAttributes<"datalist"> &
-  GlobalHTMLAttributes<"datalist">;
+  "role": (value: string) => BaseHTMLElements["datalist"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<datalistElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<datalistElement>[key] } & { (...children: children): datalistElement; };
 
 type ddElement = {
   /** If the value of this attribute is set to yes, the definition text will not wrap. The default value is no. */
-  nowrap: (value: string) => HTMLElements["dd"];
-  role: (value: string) => HTMLElements["dd"];
-} & GlobalAriaAttributes<"dd"> &
-  GlobalHTMLAttributes<"dd">;
+  "nowrap": (value: string) => BaseHTMLElements["dd"];
+  "role": (value: string) => BaseHTMLElements["dd"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<ddElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<ddElement>[key] } & { (...children: children): ddElement; };
 
 type delElement = {
-  cite: (value: string) => HTMLElements["del"];
-  datetime: (value: string) => HTMLElements["del"];
-  role: (value: string) => HTMLElements["del"];
-} & GlobalAriaAttributes<"del"> &
-  GlobalHTMLAttributes<"del">;
+  "cite": (value: string) => BaseHTMLElements["del"];
+  "datetime": (value: string) => BaseHTMLElements["del"];
+  "role": (value: string) => BaseHTMLElements["del"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<delElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<delElement>[key] } & { (...children: children): delElement; };
 
 type detailsElement = {
-  open: (value: boolean) => HTMLElements["details"];
-  role: (value: string) => HTMLElements["details"];
-} & GlobalAriaAttributes<"details"> &
-  GlobalHTMLAttributes<"details">;
+  "open": (value: boolean) => BaseHTMLElements["details"];
+  "role": (value: string) => BaseHTMLElements["details"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<detailsElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<detailsElement>[key] } & { (...children: children): detailsElement; };
 
 type dfnElement = {
-  role: (value: string) => HTMLElements["dfn"];
-} & GlobalAriaAttributes<"dfn"> &
-  GlobalHTMLAttributes<"dfn">;
+  "role": (value: string) => BaseHTMLElements["dfn"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<dfnElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<dfnElement>[key] } & { (...children: children): dfnElement; };
 
 type dialogElement = {
-  open: (value: boolean) => HTMLElements["dialog"];
-  role: (value: string) => HTMLElements["dialog"];
-} & GlobalAriaAttributes<"dialog"> &
-  GlobalHTMLAttributes<"dialog">;
+  "open": (value: boolean) => BaseHTMLElements["dialog"];
+  "role": (value: string) => BaseHTMLElements["dialog"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<dialogElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<dialogElement>[key] } & { (...children: children): dialogElement; };
 
 type dirElement = {
   /** This Boolean attribute hints that the list should be rendered in a compact style. The interpretation of this attribute depends on the user agent and it doesn't work in all browsers. */
-  compact: (value: string) => HTMLElements["dir"];
-} & GlobalAriaAttributes<"dir"> &
-  GlobalHTMLAttributes<"dir">;
+  "compact": (value: string) => BaseHTMLElements["dir"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<dirElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<dirElement>[key] } & { (...children: children): dirElement; };
 
 type divElement = {
-  role: (value: string) => HTMLElements["div"];
-} & GlobalAriaAttributes<"div"> &
-  GlobalHTMLAttributes<"div">;
+  "role": (value: string) => BaseHTMLElements["div"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<divElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<divElement>[key] } & { (...children: children): divElement; };
 
 type dlElement = {
-  role: (value: string) => HTMLElements["dl"];
-} & GlobalAriaAttributes<"dl"> &
-  GlobalHTMLAttributes<"dl">;
+  "role": (value: string) => BaseHTMLElements["dl"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<dlElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<dlElement>[key] } & { (...children: children): dlElement; };
 
 type dtElement = {
-  role: (value: string) => HTMLElements["dt"];
-} & GlobalAriaAttributes<"dt"> &
-  GlobalHTMLAttributes<"dt">;
+  "role": (value: string) => BaseHTMLElements["dt"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<dtElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<dtElement>[key] } & { (...children: children): dtElement; };
 
 type emElement = {
-  role: (value: string) => HTMLElements["em"];
-} & GlobalAriaAttributes<"em"> &
-  GlobalHTMLAttributes<"em">;
+  "role": (value: string) => BaseHTMLElements["em"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<emElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<emElement>[key] } & { (...children: children): emElement; };
 
 type embedElement = {
   /** The displayed height of the resource, in CSS pixels. This must be an absolute value; percentages are not allowed. */
-  height: (value: number) => HTMLElements["embed"];
-  role: (value: string) => HTMLElements["embed"];
-  src: (value: string) => HTMLElements["embed"];
-  type: (value: string) => HTMLElements["embed"];
+  "height": (value: number) => BaseHTMLElements["embed"];
+  "role": (value: string) => BaseHTMLElements["embed"];
+  "src": (value: string) => BaseHTMLElements["embed"];
+  "type": (value: string) => BaseHTMLElements["embed"];
   /** The displayed width of the resource, in CSS pixels. This must be an absolute value; percentages are not allowed. */
-  width: (value: number) => HTMLElements["embed"];
-} & GlobalAriaAttributes<"embed"> &
-  GlobalHTMLAttributes<"embed">;
+  "width": (value: number) => BaseHTMLElements["embed"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<embedElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<embedElement>[key] } & { (...children: children): embedElement; };
 
 type fieldsetElement = {
   /** If this Boolean attribute is set, all form controls that are descendants of the <fieldset>, are disabled, meaning they are not editable and won't be submitted along with the <form>. They won't receive any browsing events, like mouse clicks or focus-related events. By default browsers display such controls grayed out. Note that form elements inside the <legend> element won't be disabled. */
-  disabled: (value: boolean) => HTMLElements["fieldset"];
+  "disabled": (value: boolean) => BaseHTMLElements["fieldset"];
   /** This attribute takes the value of the id attribute of a <form> element you want the <fieldset> to be part of, even if it is not inside the form. Please note that usage of this is confusing — if you want the <input> elements inside the <fieldset> to be associated with the form, you need to use the form attribute directly on those elements. You can check which elements are associated with a form via JavaScript, using HTMLFormElement.elements. */
-  form: (value: string) => HTMLElements["fieldset"];
+  "form": (value: string) => BaseHTMLElements["fieldset"];
   /** The name associated with the group. Note: The caption for the fieldset is given by the first <legend> element nested inside it. */
-  name: (value: string) => HTMLElements["fieldset"];
-  role: (value: string) => HTMLElements["fieldset"];
-} & GlobalAriaAttributes<"fieldset"> &
-  GlobalHTMLAttributes<"fieldset">;
+  "name": (value: string) => BaseHTMLElements["fieldset"];
+  "role": (value: string) => BaseHTMLElements["fieldset"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<fieldsetElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<fieldsetElement>[key] } & { (...children: children): fieldsetElement; };
 
 type figcaptionElement = {
-  role: (value: string) => HTMLElements["figcaption"];
-} & GlobalAriaAttributes<"figcaption"> &
-  GlobalHTMLAttributes<"figcaption">;
+  "role": (value: string) => BaseHTMLElements["figcaption"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<figcaptionElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<figcaptionElement>[key] } & { (...children: children): figcaptionElement; };
 
 type figureElement = {
-  role: (value: string) => HTMLElements["figure"];
-} & GlobalAriaAttributes<"figure"> &
-  GlobalHTMLAttributes<"figure">;
+  "role": (value: string) => BaseHTMLElements["figure"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<figureElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<figureElement>[key] } & { (...children: children): figureElement; };
 
 type fontElement = {
   /** This attribute sets the text color using either a named color or a color specified in the hexadecimal #RRGGBB format. */
-  color: (value: string) => HTMLElements["font"];
+  "color": (value: string) => BaseHTMLElements["font"];
   /** This attribute contains a comma-separated list of one or more font names. The document text in the default style is rendered in the first font face that the client's browser supports. If no font listed is installed on the local system, the browser typically defaults to the proportional or fixed-width font for that system. */
-  face: (value: string) => HTMLElements["font"];
+  "face": (value: string) => BaseHTMLElements["font"];
   /** This attribute specifies the font size as either a numeric or relative value. Numeric values range from 1 to 7 with 1 being the smallest and 3 the default. It can be defined using a relative value, like +2 or -3, which set it relative to the value of the size attribute of the <basefont> element, or relative to 3, the default value, if none does exist. */
-  size: (value: string) => HTMLElements["font"];
-} & GlobalAriaAttributes<"font"> &
-  GlobalHTMLAttributes<"font">;
+  "size": (value: string) => BaseHTMLElements["font"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<fontElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<fontElement>[key] } & { (...children: children): fontElement; };
 
 type footerElement = {
-  role: (value: string) => HTMLElements["footer"];
-} & GlobalAriaAttributes<"footer"> &
-  GlobalHTMLAttributes<"footer">;
+  "role": (value: string) => BaseHTMLElements["footer"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<footerElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<footerElement>[key] } & { (...children: children): footerElement; };
 
 type formElement = {
   /** @deprecated Comma-separated content types the server accepts. Note: This attribute was removed in HTML5 and should not be used. Instead, use the accept attribute on <input type=file> elements. */
-  accept: (value: string) => HTMLElements["form"];
-  acceptCharset: (value: "utf-8") => HTMLElements["form"];
-  action: (value: string) => HTMLElements["form"];
-  autocomplete: (value: "on" | "off") => HTMLElements["form"];
-  enctype: (
-    value:
-      | "application/x-www-form-urlencoded"
-      | "multipart/form-data"
-      | "text/plain"
-  ) => HTMLElements["form"];
-  method: (value: "post" | "get" | "dialog") => HTMLElements["form"];
-  name: (value: string) => HTMLElements["form"];
-  novalidate: (value: boolean) => HTMLElements["form"];
-  rel: (value: string) => HTMLElements["form"];
-  role: (value: string) => HTMLElements["form"];
-  target: (value: string) => HTMLElements["form"];
-} & GlobalAriaAttributes<"form"> &
-  GlobalHTMLAttributes<"form">;
+  "accept": (value: string) => BaseHTMLElements["form"];
+  "acceptCharset": (value: "utf-8") => BaseHTMLElements["form"];
+  "action": (value: string) => BaseHTMLElements["form"];
+  "autocomplete": (value: "on" | "off") => BaseHTMLElements["form"];
+  "enctype": (value: "application/x-www-form-urlencoded" | "multipart/form-data" | "text/plain") => BaseHTMLElements["form"];
+  "method": (value: "post" | "get" | "dialog") => BaseHTMLElements["form"];
+  "name": (value: string) => BaseHTMLElements["form"];
+  "novalidate": (value: boolean) => BaseHTMLElements["form"];
+  "rel": (value: string) => BaseHTMLElements["form"];
+  "role": (value: string) => BaseHTMLElements["form"];
+  "target": (value: string) => BaseHTMLElements["form"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<formElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<formElement>[key] } & { (...children: children): formElement; };
 
 type frameElement = {
   /** This attribute allows you to specify a frame's border. */
-  frameborder: (value: string) => HTMLElements["frame"];
+  "frameborder": (value: string) => BaseHTMLElements["frame"];
   /** This attribute defines the height of the margin between frames. */
-  marginheight: (value: string) => HTMLElements["frame"];
+  "marginheight": (value: string) => BaseHTMLElements["frame"];
   /** This attribute defines the width of the margin between frames. */
-  marginwidth: (value: string) => HTMLElements["frame"];
+  "marginwidth": (value: string) => BaseHTMLElements["frame"];
   /** This attribute is used for labeling frames. Without labeling, every link will open in the frame that it's in – the closest parent frame. See the target attribute for more information. */
-  name: (value: string) => HTMLElements["frame"];
+  "name": (value: string) => BaseHTMLElements["frame"];
   /** This attribute prevents resizing of frames by users. */
-  noresize: (value: string) => HTMLElements["frame"];
+  "noresize": (value: string) => BaseHTMLElements["frame"];
   /** This attribute defines the existence of a scrollbar. If this attribute is not used, the browser adds a scrollbar when necessary. There are two choices: "yes" for forcing a scrollbar even when it is not necessary and "no" for forcing no scrollbar even when it is necessary. */
-  scrolling: (value: string) => HTMLElements["frame"];
+  "scrolling": (value: string) => BaseHTMLElements["frame"];
   /** This attribute specifies the document that will be displayed by the frame. */
-  src: (value: string) => HTMLElements["frame"];
-} & GlobalAriaAttributes<"frame"> &
-  GlobalHTMLAttributes<"frame">;
+  "src": (value: string) => BaseHTMLElements["frame"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<frameElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<frameElement>[key] } & { (...children: children): frameElement; };
 
 type framesetElement = {
   /** This attribute specifies the number and size of horizontal spaces in a frameset. */
-  cols: (value: string) => HTMLElements["frameset"];
+  "cols": (value: string) => BaseHTMLElements["frameset"];
   /** This attribute specifies the number and size of vertical spaces in a frameset. */
-  rows: (value: string) => HTMLElements["frameset"];
-} & GlobalAriaAttributes<"frameset"> &
-  GlobalHTMLAttributes<"frameset">;
+  "rows": (value: string) => BaseHTMLElements["frameset"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<framesetElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<framesetElement>[key] } & { (...children: children): framesetElement; };
 
 type h1Element = {
-  role: (value: string) => HTMLElements["h1"];
-} & GlobalAriaAttributes<"h1"> &
-  GlobalHTMLAttributes<"h1">;
+  "role": (value: string) => BaseHTMLElements["h1"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<h1Element>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<h1Element>[key] } & { (...children: children): h1Element; };
 
 type h2Element = {
-  role: (value: string) => HTMLElements["h2"];
-} & GlobalAriaAttributes<"h2"> &
-  GlobalHTMLAttributes<"h2">;
+  "role": (value: string) => BaseHTMLElements["h2"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<h2Element>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<h2Element>[key] } & { (...children: children): h2Element; };
 
 type h3Element = {
-  role: (value: string) => HTMLElements["h3"];
-} & GlobalAriaAttributes<"h3"> &
-  GlobalHTMLAttributes<"h3">;
+  "role": (value: string) => BaseHTMLElements["h3"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<h3Element>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<h3Element>[key] } & { (...children: children): h3Element; };
 
 type h4Element = {
-  role: (value: string) => HTMLElements["h4"];
-} & GlobalAriaAttributes<"h4"> &
-  GlobalHTMLAttributes<"h4">;
+  "role": (value: string) => BaseHTMLElements["h4"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<h4Element>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<h4Element>[key] } & { (...children: children): h4Element; };
 
 type h5Element = {
-  role: (value: string) => HTMLElements["h5"];
-} & GlobalAriaAttributes<"h5"> &
-  GlobalHTMLAttributes<"h5">;
+  "role": (value: string) => BaseHTMLElements["h5"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<h5Element>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<h5Element>[key] } & { (...children: children): h5Element; };
 
 type headElement = {
   /** @deprecated The URIs of one or more metadata profiles, separated by white space. */
-  profile: (value: string) => HTMLElements["head"];
-  role: (value: string) => HTMLElements["head"];
-} & GlobalAriaAttributes<"head"> &
-  GlobalHTMLAttributes<"head">;
+  "profile": (value: string) => BaseHTMLElements["head"];
+  "role": (value: string) => BaseHTMLElements["head"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<headElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<headElement>[key] } & { (...children: children): headElement; };
 
 type headerElement = {
-  role: (value: string) => HTMLElements["header"];
-} & GlobalAriaAttributes<"header"> &
-  GlobalHTMLAttributes<"header">;
+  "role": (value: string) => BaseHTMLElements["header"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<headerElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<headerElement>[key] } & { (...children: children): headerElement; };
 
 type hgroupElement = {
-  role: (value: string) => HTMLElements["hgroup"];
-} & GlobalAriaAttributes<"hgroup"> &
-  GlobalHTMLAttributes<"hgroup">;
+  "role": (value: string) => BaseHTMLElements["hgroup"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<hgroupElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<hgroupElement>[key] } & { (...children: children): hgroupElement; };
 
 type hrElement = {
   /** @deprecated Sets the alignment of the rule on the page. If no value is specified, the default value is left. */
-  align: (value: string) => HTMLElements["hr"];
+  "align": (value: string) => BaseHTMLElements["hr"];
   /** Sets the color of the rule through color name or hexadecimal value. */
-  color: (value: string) => HTMLElements["hr"];
+  "color": (value: string) => BaseHTMLElements["hr"];
   /** @deprecated Sets the rule to have no shading. */
-  noshade: (value: string) => HTMLElements["hr"];
-  role: (value: string) => HTMLElements["hr"];
+  "noshade": (value: string) => BaseHTMLElements["hr"];
+  "role": (value: string) => BaseHTMLElements["hr"];
   /** @deprecated Sets the height, in pixels, of the rule. */
-  size: (value: string) => HTMLElements["hr"];
+  "size": (value: string) => BaseHTMLElements["hr"];
   /** @deprecated Sets the length of the rule on the page through a pixel or percentage value. */
-  width: (value: string) => HTMLElements["hr"];
-} & GlobalAriaAttributes<"hr"> &
-  GlobalHTMLAttributes<"hr">;
+  "width": (value: string) => BaseHTMLElements["hr"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<hrElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<hrElement>[key] } & { (...children: children): hrElement; };
 
 type htmlElement = {
   /** @deprecated Specifies the URI of a resource manifest indicating resources that should be cached locally. */
-  manifest: (value: string) => HTMLElements["html"];
-  role: (value: string) => HTMLElements["html"];
+  "manifest": (value: string) => BaseHTMLElements["html"];
+  "role": (value: string) => BaseHTMLElements["html"];
   /** @deprecated Specifies the version of the HTML Document Type Definition that governs the current document. This attribute is not needed, because it is redundant with the version information in the document type declaration. */
-  version: (value: string) => HTMLElements["html"];
-} & GlobalAriaAttributes<"html"> &
-  GlobalHTMLAttributes<"html">;
+  "version": (value: string) => BaseHTMLElements["html"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<htmlElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<htmlElement>[key] } & { (...children: children): htmlElement; };
 
 type iElement = {
-  role: (value: string) => HTMLElements["i"];
-} & GlobalAriaAttributes<"i"> &
-  GlobalHTMLAttributes<"i">;
+  "role": (value: string) => BaseHTMLElements["i"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<iElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<iElement>[key] } & { (...children: children): iElement; };
 
 type iframeElement = {
   /** @deprecated The alignment of this element with respect to the surrounding context. */
-  align: (value: string) => HTMLElements["iframe"];
-  allow: (value: string) => HTMLElements["iframe"];
-  allowfullscreen: (value: boolean) => HTMLElements["iframe"];
+  "align": (value: string) => BaseHTMLElements["iframe"];
+  "allow": (value: string) => BaseHTMLElements["iframe"];
+  "allowfullscreen": (value: boolean) => BaseHTMLElements["iframe"];
   /** Set to true if a cross-origin <iframe> should be allowed to invoke the Payment Request API. Note: This attribute is considered a legacy attribute and redefined as allow="payment". */
-  allowpaymentrequest: (value: string) => HTMLElements["iframe"];
+  "allowpaymentrequest": (value: string) => BaseHTMLElements["iframe"];
   /** A Content Security Policy enforced for the embedded resource. See HTMLIFrameElement.csp for details. */
-  csp: (value: string) => HTMLElements["iframe"];
+  "csp": (value: string) => BaseHTMLElements["iframe"];
   /** @deprecated The value 1 (the default) draws a border around this frame. The value 0 removes the border around this frame, but you should instead use the CSS property border to control <iframe> borders. */
-  frameborder: (value: string) => HTMLElements["iframe"];
+  "frameborder": (value: string) => BaseHTMLElements["iframe"];
   /** The height of the frame in CSS pixels. Default is 150. */
-  height: (value: number) => HTMLElements["iframe"];
+  "height": (value: number) => BaseHTMLElements["iframe"];
   /** Indicates how the browser should load the iframe: eager: Load the iframe immediately, regardless if it is outside the visible viewport (this is the default value). lazy: Defer loading of the iframe until it reaches a calculated distance from the viewport, as defined by the browser. */
-  loading: (value: "lazy" | "eager") => HTMLElements["iframe"];
+  "loading": (value: "lazy" | "eager") => BaseHTMLElements["iframe"];
   /** @deprecated A URL of a long description of the frame's content. Due to widespread misuse, this is not helpful for non-visual browsers. */
-  longdesc: (value: string) => HTMLElements["iframe"];
+  "longdesc": (value: string) => BaseHTMLElements["iframe"];
   /** @deprecated The amount of space in pixels between the frame's content and its top and bottom borders. */
-  marginheight: (value: string) => HTMLElements["iframe"];
+  "marginheight": (value: string) => BaseHTMLElements["iframe"];
   /** @deprecated The amount of space in pixels between the frame's content and its left and right borders. */
-  marginwidth: (value: string) => HTMLElements["iframe"];
-  name: (value: string) => HTMLElements["iframe"];
+  "marginwidth": (value: string) => BaseHTMLElements["iframe"];
+  "name": (value: string) => BaseHTMLElements["iframe"];
   /** Indicates which referrer to send when fetching the frame's resource: no-referrer: The Referer header will not be sent. no-referrer-when-downgrade: The Referer header will not be sent to origins without TLS (HTTPS). origin: The sent referrer will be limited to the origin of the referring page: its scheme, host, and port. origin-when-cross-origin: The referrer sent to other origins will be limited to the scheme, the host, and the port. Navigations on the same origin will still include the path. same-origin: A referrer will be sent for same origin, but cross-origin requests will contain no referrer information. strict-origin: Only send the origin of the document as the referrer when the protocol security level stays the same (HTTPS→HTTPS), but don't send it to a less secure destination (HTTPS→HTTP). strict-origin-when-cross-origin (default): Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP). unsafe-url: The referrer will include the origin and the path (but not the fragment, password, or username). This value is unsafe, because it leaks origins and paths from TLS-protected resources to insecure origins. */
-  referrerpolicy: (
-    value:
-      | ""
-      | "no-referrer"
-      | "no-referrer-when-downgrade"
-      | "same-origin"
-      | "origin"
-      | "strict-origin"
-      | "origin-when-cross-origin"
-      | "strict-origin-when-cross-origin"
-      | "unsafe-url"
-  ) => HTMLElements["iframe"];
-  role: (value: string) => HTMLElements["iframe"];
-  sandbox: (value: string) => HTMLElements["iframe"];
+  "referrerpolicy": (value: "" | "no-referrer" | "no-referrer-when-downgrade" | "same-origin" | "origin" | "strict-origin" | "origin-when-cross-origin" | "strict-origin-when-cross-origin" | "unsafe-url") => BaseHTMLElements["iframe"];
+  "role": (value: string) => BaseHTMLElements["iframe"];
+  "sandbox": (value: string) => BaseHTMLElements["iframe"];
   /** @deprecated Indicates when the browser should provide a scrollbar for the frame: auto: Only when the frame's content is larger than its dimensions. yes: Always show a scrollbar. no: Never show a scrollbar. */
-  scrolling: (value: string) => HTMLElements["iframe"];
-  src: (value: string) => HTMLElements["iframe"];
-  srcdoc: (value: string) => HTMLElements["iframe"];
+  "scrolling": (value: string) => BaseHTMLElements["iframe"];
+  "src": (value: string) => BaseHTMLElements["iframe"];
+  "srcdoc": (value: string) => BaseHTMLElements["iframe"];
   /** The width of the frame in CSS pixels. Default is 300. */
-  width: (value: number) => HTMLElements["iframe"];
-} & GlobalAriaAttributes<"iframe"> &
-  GlobalHTMLAttributes<"iframe">;
+  "width": (value: number) => BaseHTMLElements["iframe"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<iframeElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<iframeElement>[key] } & { (...children: children): iframeElement; };
 
-type imageElement = {} & GlobalAriaAttributes<"image"> &
-  GlobalHTMLAttributes<"image">;
+type imageElement = {
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<imageElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<imageElement>[key] } & { (...children: children): imageElement; };
 
 type imgElement = {
   /** @deprecated Aligns the image with its surrounding context. Use the float and/or vertical-align CSS properties instead of this attribute. Allowed values: top Equivalent to vertical-align: top or vertical-align: text-top middle Equivalent to vertical-align: -moz-middle-with-baseline bottom The default, equivalent to vertical-align: unset or vertical-align: initial left Equivalent to float: left right Equivalent to float: right */
-  align: (value: string) => HTMLElements["img"];
-  alt: (value: string) => HTMLElements["img"];
+  "align": (value: string) => BaseHTMLElements["img"];
+  "alt": (value: string) => BaseHTMLElements["img"];
   /** @deprecated The width of a border around the image. Use the border CSS property instead. */
-  border: (value: string) => HTMLElements["img"];
+  "border": (value: string) => BaseHTMLElements["img"];
   /** Indicates if the fetching of the image must be done using a CORS request. Image data from a CORS-enabled image returned from a CORS request can be reused in the <canvas> element without being marked "tainted". If the crossorigin attribute is not specified, then a non-CORS request is sent (without the Origin request header), and the browser marks the image as tainted and restricts access to its image data, preventing its usage in <canvas> elements. If the crossorigin attribute is specified, then a CORS request is sent (with the Origin request header); but if the server does not opt into allowing cross-origin access to the image data by the origin site (by not sending any Access-Control-Allow-Origin response header, or by not including the site's origin in any Access-Control-Allow-Origin response header it does send), then the browser blocks the image from loading, and logs a CORS error to the devtools console. Allowed values: anonymous A CORS request is sent with credentials omitted (that is, no cookies, X.509 certificates, or Authorization request header). use-credentials The CORS request is sent with any credentials included (that is, cookies, X.509 certificates, and the Authorization request header). If the server does not opt into sharing credentials with the origin site (by sending back the Access-Control-Allow-Credentials: true response header), then the browser marks the image as tainted and restricts access to its image data. If the attribute has an invalid value, browsers handle it as if the anonymous value was used. See CORS settings attributes for additional information. */
-  crossorigin: (
-    value: "" | "anonymous" | "use-credentials"
-  ) => HTMLElements["img"];
-  decoding: (value: "sync" | "async" | "auto") => HTMLElements["img"];
+  "crossorigin": (value: "" | "anonymous" | "use-credentials") => BaseHTMLElements["img"];
+  "decoding": (value: "sync" | "async" | "auto") => BaseHTMLElements["img"];
   /** The intrinsic height of the image, in pixels. Must be an integer without a unit. */
-  height: (value: number) => HTMLElements["img"];
+  "height": (value: number) => BaseHTMLElements["img"];
   /** @deprecated The number of pixels of white space on the left and right of the image. Use the margin CSS property instead. */
-  hspace: (value: string) => HTMLElements["img"];
+  "hspace": (value: string) => BaseHTMLElements["img"];
   /** @deprecated This attribute tells the browser to ignore the actual intrinsic size of the image and pretend it's the size specified in the attribute. Specifically, the image would raster at these dimensions and naturalWidth/naturalHeight on images would return the values specified in this attribute. Explainer, examples */
-  intrinsicsize: (value: string) => HTMLElements["img"];
-  ismap: (value: boolean) => HTMLElements["img"];
+  "intrinsicsize": (value: string) => BaseHTMLElements["img"];
+  "ismap": (value: boolean) => BaseHTMLElements["img"];
   /** Indicates how the browser should load the image: eager: Loads the image immediately, regardless of whether or not the image is currently within the visible viewport (this is the default value). lazy: Defers loading the image until it reaches a calculated distance from the viewport, as defined by the browser. The intent is to avoid the network and storage bandwidth needed to handle the image until it's reasonably certain that it will be needed. This generally improves the performance of the content in most typical use cases. Note: Loading is only deferred when JavaScript is enabled. This is an anti-tracking measure, because if a user agent supported lazy loading when scripting is disabled, it would still be possible for a site to track a user's approximate scroll position throughout a session, by strategically placing images in a page's markup such that a server can track how many images are requested and when. */
-  loading: (value: "lazy" | "eager") => HTMLElements["img"];
+  "loading": (value: "lazy" | "eager") => BaseHTMLElements["img"];
   /** @deprecated A link to a more detailed description of the image. Possible values are a URL or an element id. Note: This attribute is mentioned in the latest W3C version, HTML 5.2, but has been removed from the WHATWG's HTML Living Standard. It has an uncertain future; authors should use a WAI-ARIA alternative such as aria-describedby or aria-details. */
-  longdesc: (value: string) => HTMLElements["img"];
+  "longdesc": (value: string) => BaseHTMLElements["img"];
   /** @deprecated A name for the element. Use the id attribute instead. */
-  name: (value: string) => HTMLElements["img"];
+  "name": (value: string) => BaseHTMLElements["img"];
   /** A string indicating which referrer to use when fetching the resource: no-referrer: The Referer header will not be sent. no-referrer-when-downgrade: The Referer header will not be sent to origins without TLS (HTTPS). origin: The sent referrer will be limited to the origin of the referring page: its scheme, host, and port. origin-when-cross-origin: The referrer sent to other origins will be limited to the scheme, the host, and the port. Navigations on the same origin will still include the path. same-origin: A referrer will be sent for same origin, but cross-origin requests will contain no referrer information. strict-origin: Only send the origin of the document as the referrer when the protocol security level stays the same (HTTPS→HTTPS), but don't send it to a less secure destination (HTTPS→HTTP). strict-origin-when-cross-origin (default): Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP). unsafe-url: The referrer will include the origin and the path (but not the fragment, password, or username). This value is unsafe, because it leaks origins and paths from TLS-protected resources to insecure origins. */
-  referrerpolicy: (
-    value:
-      | ""
-      | "no-referrer"
-      | "no-referrer-when-downgrade"
-      | "same-origin"
-      | "origin"
-      | "strict-origin"
-      | "origin-when-cross-origin"
-      | "strict-origin-when-cross-origin"
-      | "unsafe-url"
-  ) => HTMLElements["img"];
-  role: (value: string) => HTMLElements["img"];
+  "referrerpolicy": (value: "" | "no-referrer" | "no-referrer-when-downgrade" | "same-origin" | "origin" | "strict-origin" | "origin-when-cross-origin" | "strict-origin-when-cross-origin" | "unsafe-url") => BaseHTMLElements["img"];
+  "role": (value: string) => BaseHTMLElements["img"];
   /** One or more strings separated by commas, indicating a set of source sizes. Each source size consists of: A media condition. This must be omitted for the last item in the list. A source size value. Media Conditions describe properties of the viewport, not of the image. For example, (max-height: 500px) 1000px proposes to use a source of 1000px width, if the viewport is not higher than 500px. Source size values specify the intended display size of the image. User agents use the current source size to select one of the sources supplied by the srcset attribute, when those sources are described using width (w) descriptors. The selected source size affects the intrinsic size of the image (the image's display size if no CSS styling is applied). If the srcset attribute is absent, or contains no values with a width descriptor, then the sizes attribute has no effect. */
-  sizes: (value: string) => HTMLElements["img"];
-  src: (value: string) => HTMLElements["img"];
+  "sizes": (value: string) => BaseHTMLElements["img"];
+  "src": (value: string) => BaseHTMLElements["img"];
   /** One or more strings separated by commas, indicating possible image sources for the user agent to use. Each string is composed of: A URL to an image Optionally, whitespace followed by one of: A width descriptor (a positive integer directly followed by w). The width descriptor is divided by the source size given in the sizes attribute to calculate the effective pixel density. A pixel density descriptor (a positive floating point number directly followed by x). If no descriptor is specified, the source is assigned the default descriptor of 1x. It is incorrect to mix width descriptors and pixel density descriptors in the same srcset attribute. Duplicate descriptors (for instance, two sources in the same srcset which are both described with 2x) are also invalid. The user agent selects any of the available sources at its discretion. This provides them with significant leeway to tailor their selection based on things like user preferences or bandwidth conditions. See our Responsive images tutorial for an example. */
-  srcset: (value: string) => HTMLElements["img"];
-  usemap: (value: string) => HTMLElements["img"];
+  "srcset": (value: string) => BaseHTMLElements["img"];
+  "usemap": (value: string) => BaseHTMLElements["img"];
   /** @deprecated The number of pixels of white space above and below the image. Use the margin CSS property instead. */
-  vspace: (value: string) => HTMLElements["img"];
+  "vspace": (value: string) => BaseHTMLElements["img"];
   /** The intrinsic width of the image in pixels. Must be an integer without a unit. */
-  width: (value: number) => HTMLElements["img"];
-} & GlobalAriaAttributes<"img"> &
-  GlobalHTMLAttributes<"img">;
+  "width": (value: number) => BaseHTMLElements["img"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<imgElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<imgElement>[key] } & { (...children: children): imgElement; };
 
 type inputElement = {
-  accept: (value: string) => HTMLElements["input"];
-  alt: (value: string) => HTMLElements["input"];
-  autocomplete: (value: string) => HTMLElements["input"];
+  "accept": (value: string) => BaseHTMLElements["input"];
+  "alt": (value: string) => BaseHTMLElements["input"];
+  "autocomplete": (value: string) => BaseHTMLElements["input"];
   /** A Safari extension, the autocorrect attribute is a string which indicates whether or not to activate automatic correction while the user is editing this field. Permitted values are: on Enable automatic correction of typos, as well as processing of text substitutions if any are configured. off Disable automatic correction and text substitutions. */
-  autocorrect: (value: string) => HTMLElements["input"];
+  "autocorrect": (value: string) => BaseHTMLElements["input"];
   /** Introduced in the HTML Media Capture specification and valid for the file input type only, the capture attribute defines which media—microphone, video, or camera—should be used to capture a new file for upload with file upload control in supporting scenarios. See the file input type. */
-  capture: (value: string) => HTMLElements["input"];
-  checked: (value: boolean) => HTMLElements["input"];
-  dirname: (value: string) => HTMLElements["input"];
+  "capture": (value: string) => BaseHTMLElements["input"];
+  "checked": (value: boolean) => BaseHTMLElements["input"];
+  "dirname": (value: string) => BaseHTMLElements["input"];
   /** A Boolean attribute which, if present, indicates that the user should not be able to interact with the input. Disabled inputs are typically rendered with a dimmer color or using some other form of indication that the field is not available for use. Specifically, disabled inputs do not receive the click event, and disabled inputs are not submitted with the form. Note: Although not required by the specification, Firefox will by default persist the dynamic disabled state of an <input> across page loads. Use the autocomplete attribute to control this feature. */
-  disabled: (value: boolean) => HTMLElements["input"];
+  "disabled": (value: boolean) => BaseHTMLElements["input"];
   /** A string specifying the <form> element with which the input is associated (that is, its form owner). This string's value, if present, must match the id of a <form> element in the same document. If this attribute isn't specified, the <input> element is associated with the nearest containing form, if any. The form attribute lets you place an input anywhere in the document but have it included with a form elsewhere in the document. Note: An input can only be associated with one form. */
-  form: (value: string) => HTMLElements["input"];
+  "form": (value: string) => BaseHTMLElements["input"];
   /** Valid for the image and submit input types only. See the submit input type for more information. */
-  formaction: (value: string) => HTMLElements["input"];
+  "formaction": (value: string) => BaseHTMLElements["input"];
   /** Valid for the image and submit input types only. See the submit input type for more information. */
-  formenctype: (
-    value:
-      | "application/x-www-form-urlencoded"
-      | "multipart/form-data"
-      | "text/plain"
-  ) => HTMLElements["input"];
+  "formenctype": (value: "application/x-www-form-urlencoded" | "multipart/form-data" | "text/plain") => BaseHTMLElements["input"];
   /** Valid for the image and submit input types only. See the submit input type for more information. */
-  formmethod: (value: "post" | "get" | "dialog") => HTMLElements["input"];
+  "formmethod": (value: "post" | "get" | "dialog") => BaseHTMLElements["input"];
   /** Valid for the image and submit input types only. See the submit input type for more information. */
-  formnovalidate: (value: boolean) => HTMLElements["input"];
+  "formnovalidate": (value: boolean) => BaseHTMLElements["input"];
   /** Valid for the image and submit input types only. See the submit input type for more information. */
-  formtarget: (value: string) => HTMLElements["input"];
-  height: (value: number) => HTMLElements["input"];
+  "formtarget": (value: string) => BaseHTMLElements["input"];
+  "height": (value: number) => BaseHTMLElements["input"];
   /** The Boolean attribute incremental is a WebKit and Blink extension (so supported by Safari, Opera, Chrome, etc.) which, if present, tells the user agent to process the input as a live search. As the user edits the value of the field, the user agent sends search events to the HTMLInputElement object representing the search box. This allows your code to update the search results in real time as the user edits the search. If incremental is not specified, the search event is only sent when the user explicitly initiates a search (such as by pressing the Enter or Return key while editing the field). The search event is rate-limited so that it is not sent more frequently than an implementation-defined interval. */
-  incremental: (value: string) => HTMLElements["input"];
-  list: (value: string) => HTMLElements["input"];
-  max: (value: string) => HTMLElements["input"];
-  maxlength: (value: number) => HTMLElements["input"];
-  min: (value: string) => HTMLElements["input"];
-  minlength: (value: number) => HTMLElements["input"];
+  "incremental": (value: string) => BaseHTMLElements["input"];
+  "list": (value: string) => BaseHTMLElements["input"];
+  "max": (value: string) => BaseHTMLElements["input"];
+  "maxlength": (value: number) => BaseHTMLElements["input"];
+  "min": (value: string) => BaseHTMLElements["input"];
+  "minlength": (value: number) => BaseHTMLElements["input"];
   /** A Mozilla extension, supported by Firefox for Android, which provides a hint as to what sort of action will be taken if the user presses the Enter or Return key while editing the field. This information is used to decide what kind of label to use on the Enter key on the virtual keyboard. Note: This has been standardized as the global attribute enterkeyhint, but is not yet widely implemented. To see the status of the change being implemented in Firefox, see bug 1490661. Permitted values are: go, done, next, search, and send. The browser decides, using this hint, what label to put on the enter key. */
-  mozactionhint: (value: string) => HTMLElements["input"];
-  multiple: (value: boolean) => HTMLElements["input"];
+  "mozactionhint": (value: string) => BaseHTMLElements["input"];
+  "multiple": (value: boolean) => BaseHTMLElements["input"];
   /** A string specifying a name for the input control. This name is submitted along with the control's value when the form data is submitted. Consider the name a required attribute (even though it's not). If an input has no name specified, or name is empty, the input's value is not submitted with the form! (Disabled controls, unchecked radio buttons, unchecked checkboxes, and reset buttons are also not sent.) There are two special cases: _charset_ : If used as the name of an <input> element of type hidden, the input's value is automatically set by the user agent to the character encoding being used to submit the form. isindex: For historical reasons, the name isindex is not allowed. The name attribute creates a unique behavior for radio buttons. Only one radio button in a same-named group of radio buttons can be checked at a time. Selecting any radio button in that group automatically deselects any currently-selected radio button in the same group. The value of that one checked radio button is sent along with the name if the form is submitted, When tabbing into a series of same-named group of radio buttons, if one is checked, that one will receive focus. If they aren't grouped together in source order, if one of the group is checked, tabbing into the group starts when the first one in the group is encountered, skipping all those that aren't checked. In other words, if one is checked, tabbing skips the unchecked radio buttons in the group. If none are checked, the radio button group receives focus when the first button in the same name group is reached. Once one of the radio buttons in a group has focus, using the arrow keys will navigate through all the radio buttons of the same name, even if the radio buttons are not grouped together in the source order. When an input element is given a name, that name becomes a property of the owning form element's HTMLFormElement.elements property. If you have an input whose name is set to guest and another whose name is hat-size, the following code can be used: let form = document.querySelector("form"); let guestName = form.elements.guest; let hatSize = form.elements["hat-size"]; When this code has run, guestName will be the HTMLInputElement for the guest field, and hatSize the object for the hat-size field. Warning: Avoid giving form elements a name that corresponds to a built-in property of the form, since you would then override the predefined property or method with this reference to the corresponding input. */
-  name: (value: string) => HTMLElements["input"];
+  "name": (value: string) => BaseHTMLElements["input"];
   /** Similar to the -moz-orient non-standard CSS property impacting the <progress> and <meter> elements, the orient attribute defines the orientation of the range slider. Values include horizontal, meaning the range is rendered horizontally, and vertical, where the range is rendered vertically. */
-  orient: (value: string) => HTMLElements["input"];
-  pattern: (value: string) => HTMLElements["input"];
-  placeholder: (value: string) => HTMLElements["input"];
-  readonly: (value: boolean) => HTMLElements["input"];
-  required: (value: boolean) => HTMLElements["input"];
+  "orient": (value: string) => BaseHTMLElements["input"];
+  "pattern": (value: string) => BaseHTMLElements["input"];
+  "placeholder": (value: string) => BaseHTMLElements["input"];
+  "readonly": (value: boolean) => BaseHTMLElements["input"];
+  "required": (value: boolean) => BaseHTMLElements["input"];
   /** The results attribute—supported only by Safari—is a numeric value that lets you override the maximum number of entries to be displayed in the <input> element's natively-provided drop-down menu of previous search queries. The value must be a non-negative decimal number. If not provided, or an invalid value is given, the browser's default maximum number of entries is used. */
-  results: (value: string) => HTMLElements["input"];
-  role: (value: string) => HTMLElements["input"];
-  size: (value: string) => HTMLElements["input"];
-  src: (value: string) => HTMLElements["input"];
-  step: (value: string) => HTMLElements["input"];
-  type: (
-    value:
-      | "hidden"
-      | "text"
-      | "search"
-      | "tel"
-      | "url"
-      | "email"
-      | "password"
-      | "date"
-      | "month"
-      | "week"
-      | "time"
-      | "datetime-local"
-      | "number"
-      | "range"
-      | "color"
-      | "checkbox"
-      | "radio"
-      | "file"
-      | "submit"
-      | "image"
-      | "reset"
-      | "button"
-  ) => HTMLElements["input"];
-  value: (value: string) => HTMLElements["input"];
+  "results": (value: string) => BaseHTMLElements["input"];
+  "role": (value: string) => BaseHTMLElements["input"];
+  "size": (value: string) => BaseHTMLElements["input"];
+  "src": (value: string) => BaseHTMLElements["input"];
+  "step": (value: string) => BaseHTMLElements["input"];
+  "type": (value: "hidden" | "text" | "search" | "tel" | "url" | "email" | "password" | "date" | "month" | "week" | "time" | "datetime-local" | "number" | "range" | "color" | "checkbox" | "radio" | "file" | "submit" | "image" | "reset" | "button") => BaseHTMLElements["input"];
+  "value": (value: string) => BaseHTMLElements["input"];
   /** The Boolean webkitdirectory attribute, if present, indicates that only directories should be available to be selected by the user in the file picker interface. See HTMLInputElement.webkitdirectory for additional details and examples. Though originally implemented only for WebKit-based browsers, webkitdirectory is also usable in Microsoft Edge as well as Firefox 50 and later. However, even though it has relatively broad support, it is still not standard and should not be used unless you have no alternative. */
-  webkitdirectory: (value: string) => HTMLElements["input"];
-  width: (value: number) => HTMLElements["input"];
-} & GlobalAriaAttributes<"input"> &
-  GlobalHTMLAttributes<"input">;
+  "webkitdirectory": (value: string) => BaseHTMLElements["input"];
+  "width": (value: number) => BaseHTMLElements["input"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<inputElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<inputElement>[key] } & { (...children: children): inputElement; };
 
 type insElement = {
-  cite: (value: string) => HTMLElements["ins"];
-  datetime: (value: string) => HTMLElements["ins"];
-  role: (value: string) => HTMLElements["ins"];
-} & GlobalAriaAttributes<"ins"> &
-  GlobalHTMLAttributes<"ins">;
+  "cite": (value: string) => BaseHTMLElements["ins"];
+  "datetime": (value: string) => BaseHTMLElements["ins"];
+  "role": (value: string) => BaseHTMLElements["ins"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<insElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<insElement>[key] } & { (...children: children): insElement; };
 
-type isindexElement = {} & GlobalAriaAttributes<"isindex"> &
-  GlobalHTMLAttributes<"isindex">;
+type isindexElement = {
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<isindexElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<isindexElement>[key] } & { (...children: children): isindexElement; };
 
 type kbdElement = {
-  role: (value: string) => HTMLElements["kbd"];
-} & GlobalAriaAttributes<"kbd"> &
-  GlobalHTMLAttributes<"kbd">;
+  "role": (value: string) => BaseHTMLElements["kbd"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<kbdElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<kbdElement>[key] } & { (...children: children): kbdElement; };
 
 type keygenElement = {
   /** A challenge string that is submitted along with the public key. Defaults to an empty string if not specified. */
-  challenge: (value: string) => HTMLElements["keygen"];
+  "challenge": (value: string) => BaseHTMLElements["keygen"];
   /** This Boolean attribute indicates that the form control is not available for interaction. */
-  disabled: (value: string) => HTMLElements["keygen"];
+  "disabled": (value: string) => BaseHTMLElements["keygen"];
   /** The form element that this element is associated with (its form owner). The value of the attribute must be an id of a <form> element in the same document. If this attribute is not specified, this element must be a descendant of a <form> element. This attribute enables you to place <keygen> elements anywhere within a document, not just as descendants of their form elements. */
-  form: (value: string) => HTMLElements["keygen"];
+  "form": (value: string) => BaseHTMLElements["keygen"];
   /** The type of key generated. The default value is RSA. */
-  keytype: (value: string) => HTMLElements["keygen"];
+  "keytype": (value: string) => BaseHTMLElements["keygen"];
   /** The name of the control, which is submitted with the form data. */
-  name: (value: string) => HTMLElements["keygen"];
-} & GlobalAriaAttributes<"keygen"> &
-  GlobalHTMLAttributes<"keygen">;
+  "name": (value: string) => BaseHTMLElements["keygen"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<keygenElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<keygenElement>[key] } & { (...children: children): keygenElement; };
 
 type labelElement = {
-  for: (value: string) => HTMLElements["label"];
-  role: (value: string) => HTMLElements["label"];
-} & GlobalAriaAttributes<"label"> &
-  GlobalHTMLAttributes<"label">;
+  "for": (value: string) => BaseHTMLElements["label"];
+  "role": (value: string) => BaseHTMLElements["label"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<labelElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<labelElement>[key] } & { (...children: children): labelElement; };
 
 type legendElement = {
-  role: (value: string) => HTMLElements["legend"];
-} & GlobalAriaAttributes<"legend"> &
-  GlobalHTMLAttributes<"legend">;
+  "role": (value: string) => BaseHTMLElements["legend"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<legendElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<legendElement>[key] } & { (...children: children): legendElement; };
 
 type liElement = {
-  role: (value: string) => HTMLElements["li"];
+  "role": (value: string) => BaseHTMLElements["li"];
   /** @deprecated This character attribute indicates the numbering type: a: lowercase letters A: uppercase letters i: lowercase Roman numerals I: uppercase Roman numerals 1: numbers This type overrides the one used by its parent <ol> element, if any. Note: This attribute has been deprecated; use the CSS list-style-type property instead. */
-  type: (value: string) => HTMLElements["li"];
-  value: (value: string) => HTMLElements["li"];
-} & GlobalAriaAttributes<"li"> &
-  GlobalHTMLAttributes<"li">;
+  "type": (value: string) => BaseHTMLElements["li"];
+  "value": (value: string) => BaseHTMLElements["li"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<liElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<liElement>[key] } & { (...children: children): liElement; };
 
 type linkElement = {
-  as: (
-    value:
-      | "fetch"
-      | "audio"
-      | "audioworklet"
-      | "document"
-      | "embed"
-      | "font"
-      | "frame"
-      | "iframe"
-      | "image"
-      | "manifest"
-      | "object"
-      | "paintworklet"
-      | "report"
-      | "script"
-      | "serviceworker"
-      | "sharedworker"
-      | "style"
-      | "track"
-      | "video"
-      | "worker"
-      | "xslt"
-  ) => HTMLElements["link"];
-  blocking: (value: "render") => HTMLElements["link"];
+  "as": (value: "fetch" | "audio" | "audioworklet" | "document" | "embed" | "font" | "frame" | "iframe" | "image" | "manifest" | "object" | "paintworklet" | "report" | "script" | "serviceworker" | "sharedworker" | "style" | "track" | "video" | "worker" | "xslt") => BaseHTMLElements["link"];
+  "blocking": (value: "render") => BaseHTMLElements["link"];
   /** @deprecated This attribute defines the character encoding of the linked resource. The value is a space- and/or comma-delimited list of character sets as defined in RFC 2045. The default value is iso-8859-1. Note: To produce the same effect as this obsolete attribute, use the Content-Type HTTP header on the linked resource. */
-  charset: (value: string) => HTMLElements["link"];
-  color: (value: string) => HTMLElements["link"];
+  "charset": (value: string) => BaseHTMLElements["link"];
+  "color": (value: string) => BaseHTMLElements["link"];
   /** This enumerated attribute indicates whether CORS must be used when fetching the resource. CORS-enabled images can be reused in the <canvas> element without being tainted. The allowed values are: anonymous A cross-origin request (i.e. with an Origin HTTP header) is performed, but no credential is sent (i.e. no cookie, X.509 certificate, or HTTP Basic authentication). If the server does not give credentials to the origin site (by not setting the Access-Control-Allow-Origin HTTP header) the resource will be tainted and its usage restricted. use-credentials A cross-origin request (i.e. with an Origin HTTP header) is performed along with a credential sent (i.e. a cookie, certificate, and/or HTTP Basic authentication is performed). If the server does not give credentials to the origin site (through Access-Control-Allow-Credentials HTTP header), the resource will be tainted and its usage restricted. If the attribute is not present, the resource is fetched without a CORS request (i.e. without sending the Origin HTTP header), preventing its non-tainted usage. If invalid, it is handled as if the enumerated keyword anonymous was used. See CORS settings attributes for additional information. */
-  crossorigin: (
-    value: "" | "anonymous" | "use-credentials"
-  ) => HTMLElements["link"];
-  disabled: (value: boolean) => HTMLElements["link"];
+  "crossorigin": (value: "" | "anonymous" | "use-credentials") => BaseHTMLElements["link"];
+  "disabled": (value: boolean) => BaseHTMLElements["link"];
   /** This attribute specifies the URL of the linked resource. A URL can be absolute or relative. */
-  href: (value: string) => HTMLElements["link"];
+  "href": (value: string) => BaseHTMLElements["link"];
   /** This attribute indicates the language of the linked resource. It is purely advisory. Allowed values are specified by RFC 5646: Tags for Identifying Languages (also known as BCP 47). Use this attribute only if the href attribute is present. */
-  hreflang: (value: string) => HTMLElements["link"];
-  imagesizes: (value: string) => HTMLElements["link"];
-  imagesrcset: (value: string) => HTMLElements["link"];
-  integrity: (value: string) => HTMLElements["link"];
+  "hreflang": (value: string) => BaseHTMLElements["link"];
+  "imagesizes": (value: string) => BaseHTMLElements["link"];
+  "imagesrcset": (value: string) => BaseHTMLElements["link"];
+  "integrity": (value: string) => BaseHTMLElements["link"];
   /** This attribute specifies the media that the linked resource applies to. Its value must be a media type / media query. This attribute is mainly useful when linking to external stylesheets — it allows the user agent to pick the best adapted one for the device it runs on. Note: In HTML 4, this can only be a simple white-space-separated list of media description literals, i.e., media types and groups, where defined and allowed as values for this attribute, such as print, screen, aural, braille. HTML5 extended this to any kind of media queries, which are a superset of the allowed values of HTML 4. Browsers not supporting CSS3 Media Queries won't necessarily recognize the adequate link; do not forget to set fallback links, the restricted set of media queries defined in HTML 4. */
-  media: (value: string) => HTMLElements["link"];
+  "media": (value: string) => BaseHTMLElements["link"];
   /** The value of this attribute provides information about the functions that might be performed on an object. The values generally are given by the HTTP protocol when it is used, but it might (for similar reasons as for the title attribute) be useful to include advisory information in advance in the link. For example, the browser might choose a different rendering of a link as a function of the methods specified; something that is searchable might get a different icon, or an outside link might render with an indication of leaving the current site. This attribute is not well understood nor supported, even by the defining browser, Internet Explorer 4. */
-  methods: (value: string) => HTMLElements["link"];
+  "methods": (value: string) => BaseHTMLElements["link"];
   /** Identifies a resource that might be required by the next navigation and that the user agent should retrieve it. This allows the user agent to respond faster when the resource is requested in the future. */
-  prefetch: (value: string) => HTMLElements["link"];
+  "prefetch": (value: string) => BaseHTMLElements["link"];
   /** A string indicating which referrer to use when fetching the resource: no-referrer means that the Referer header will not be sent. no-referrer-when-downgrade means that no Referer header will be sent when navigating to an origin without TLS (HTTPS). This is a user agent's default behavior, if no policy is otherwise specified. origin means that the referrer will be the origin of the page, which is roughly the scheme, the host, and the port. origin-when-cross-origin means that navigating to other origins will be limited to the scheme, the host, and the port, while navigating on the same origin will include the referrer's path. unsafe-url means that the referrer will include the origin and the path (but not the fragment, password, or username). This case is unsafe because it can leak origins and paths from TLS-protected resources to insecure origins. */
-  referrerpolicy: (
-    value:
-      | ""
-      | "no-referrer"
-      | "no-referrer-when-downgrade"
-      | "same-origin"
-      | "origin"
-      | "strict-origin"
-      | "origin-when-cross-origin"
-      | "strict-origin-when-cross-origin"
-      | "unsafe-url"
-  ) => HTMLElements["link"];
-  rel: (value: string) => HTMLElements["link"];
+  "referrerpolicy": (value: "" | "no-referrer" | "no-referrer-when-downgrade" | "same-origin" | "origin" | "strict-origin" | "origin-when-cross-origin" | "strict-origin-when-cross-origin" | "unsafe-url") => BaseHTMLElements["link"];
+  "rel": (value: string) => BaseHTMLElements["link"];
   /** @deprecated The value of this attribute shows the relationship of the current document to the linked document, as defined by the href attribute. The attribute thus defines the reverse relationship compared to the value of the rel attribute. Link type values for the attribute are similar to the possible values for rel. Note: Instead of rev, you should use the rel attribute with the opposite link type value. For example, to establish the reverse link for made, specify author. Also this attribute doesn't stand for "revision" and must not be used with a version number, even though many sites misuse it in this way. */
-  rev: (value: string) => HTMLElements["link"];
-  role: (value: string) => HTMLElements["link"];
-  sizes: (value: string) => HTMLElements["link"];
+  "rev": (value: string) => BaseHTMLElements["link"];
+  "role": (value: string) => BaseHTMLElements["link"];
+  "sizes": (value: string) => BaseHTMLElements["link"];
   /** Defines the frame or window name that has the defined linking relationship or that will show the rendering of any linked resource. */
-  target: (value: string) => HTMLElements["link"];
+  "target": (value: string) => BaseHTMLElements["link"];
   /** This attribute is used to define the type of the content linked to. The value of the attribute should be a MIME type such as text/html, text/css, and so on. The common use of this attribute is to define the type of stylesheet being referenced (such as text/css), but given that CSS is the only stylesheet language used on the web, not only is it possible to omit the type attribute, but is actually now recommended practice. It is also used on rel="preload" link types, to make sure the browser only downloads file types that it supports. */
-  type: (value: string) => HTMLElements["link"];
-} & GlobalAriaAttributes<"link"> &
-  GlobalHTMLAttributes<"link">;
+  "type": (value: string) => BaseHTMLElements["link"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<linkElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<linkElement>[key] } & { (...children: children): linkElement; };
 
-type listingElement = {} & GlobalAriaAttributes<"listing"> &
-  GlobalHTMLAttributes<"listing">;
+type listingElement = {
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<listingElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<listingElement>[key] } & { (...children: children): listingElement; };
 
 type mainElement = {
-  role: (value: string) => HTMLElements["main"];
-} & GlobalAriaAttributes<"main"> &
-  GlobalHTMLAttributes<"main">;
+  "role": (value: string) => BaseHTMLElements["main"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<mainElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<mainElement>[key] } & { (...children: children): mainElement; };
 
 type mapElement = {
-  name: (value: string) => HTMLElements["map"];
-  role: (value: string) => HTMLElements["map"];
-} & GlobalAriaAttributes<"map"> &
-  GlobalHTMLAttributes<"map">;
+  "name": (value: string) => BaseHTMLElements["map"];
+  "role": (value: string) => BaseHTMLElements["map"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<mapElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<mapElement>[key] } & { (...children: children): mapElement; };
 
 type markElement = {
-  role: (value: string) => HTMLElements["mark"];
-} & GlobalAriaAttributes<"mark"> &
-  GlobalHTMLAttributes<"mark">;
+  "role": (value: string) => BaseHTMLElements["mark"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<markElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<markElement>[key] } & { (...children: children): markElement; };
 
 type marqueeElement = {
   /** Sets how the text is scrolled within the marquee. Possible values are scroll, slide and alternate. If no value is specified, the default value is scroll. */
-  behavior: (value: string) => HTMLElements["marquee"];
+  "behavior": (value: string) => BaseHTMLElements["marquee"];
   /** Sets the background color through color name or hexadecimal value. */
-  bgcolor: (value: string) => HTMLElements["marquee"];
+  "bgcolor": (value: string) => BaseHTMLElements["marquee"];
   /** Sets the direction of the scrolling within the marquee. Possible values are left, right, up and down. If no value is specified, the default value is left. */
-  direction: (value: string) => HTMLElements["marquee"];
+  "direction": (value: string) => BaseHTMLElements["marquee"];
   /** Sets the height in pixels or percentage value. */
-  height: (value: string) => HTMLElements["marquee"];
+  "height": (value: string) => BaseHTMLElements["marquee"];
   /** Sets the horizontal margin */
-  hspace: (value: string) => HTMLElements["marquee"];
+  "hspace": (value: string) => BaseHTMLElements["marquee"];
   /** Sets the number of times the marquee will scroll. If no value is specified, the default value is −1, which means the marquee will scroll continuously. */
-  loop: (value: string) => HTMLElements["marquee"];
+  "loop": (value: string) => BaseHTMLElements["marquee"];
   /** Sets the amount of scrolling at each interval in pixels. The default value is 6. */
-  scrollamount: (value: string) => HTMLElements["marquee"];
+  "scrollamount": (value: string) => BaseHTMLElements["marquee"];
   /** Sets the interval between each scroll movement in milliseconds. The default value is 85. Note that any value smaller than 60 is ignored and the value 60 is used instead, unlesstruespeedis specified. */
-  scrolldelay: (value: string) => HTMLElements["marquee"];
+  "scrolldelay": (value: string) => BaseHTMLElements["marquee"];
   /** By default,scrolldelayvalues lower than 60 are ignored. Iftruespeedis present, those values are not ignored. */
-  truespeed: (value: string) => HTMLElements["marquee"];
+  "truespeed": (value: string) => BaseHTMLElements["marquee"];
   /** Sets the vertical margin in pixels or percentage value. */
-  vspace: (value: string) => HTMLElements["marquee"];
+  "vspace": (value: string) => BaseHTMLElements["marquee"];
   /** Sets the width in pixels or percentage value. */
-  width: (value: string) => HTMLElements["marquee"];
-} & GlobalAriaAttributes<"marquee"> &
-  GlobalHTMLAttributes<"marquee">;
+  "width": (value: string) => BaseHTMLElements["marquee"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<marqueeElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<marqueeElement>[key] } & { (...children: children): marqueeElement; };
 
 type menuElement = {
-  role: (value: string) => HTMLElements["menu"];
-} & GlobalAriaAttributes<"menu"> &
-  GlobalHTMLAttributes<"menu">;
+  "role": (value: string) => BaseHTMLElements["menu"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<menuElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<menuElement>[key] } & { (...children: children): menuElement; };
 
 type menuitemElement = {
   /** Boolean attribute which indicates whether the command is selected. May only be used when the type attribute is checkbox or radio. */
-  checked: (value: string) => HTMLElements["menuitem"];
+  "checked": (value: string) => BaseHTMLElements["menuitem"];
   /** Specifies the ID of a separate element, indicating a command to be invoked indirectly. May not be used within a menu item that also includes the attributes checked, disabled, icon, label, radiogroup or type. */
-  command: (value: string) => HTMLElements["menuitem"];
+  "command": (value: string) => BaseHTMLElements["menuitem"];
   /** This Boolean attribute indicates use of the same command as the menu's subject element (such as a button or input). */
-  default: (value: string) => HTMLElements["menuitem"];
+  "default": (value: string) => BaseHTMLElements["menuitem"];
   /** Boolean attribute which indicates that the command is not available in the current state. Note that disabled is distinct from hidden; the disabled attribute is appropriate in any context where a change in circumstances might render the command relevant. */
-  disabled: (value: string) => HTMLElements["menuitem"];
+  "disabled": (value: string) => BaseHTMLElements["menuitem"];
   /** Image URL, used to provide a picture to represent the command. */
-  icon: (value: string) => HTMLElements["menuitem"];
+  "icon": (value: string) => BaseHTMLElements["menuitem"];
   /** The name of the command as shown to the user. Required when a command attribute is not present. */
-  label: (value: string) => HTMLElements["menuitem"];
+  "label": (value: string) => BaseHTMLElements["menuitem"];
   /** This attribute specifies the name of a group of commands to be toggled as radio buttons when selected. May only be used where the type attribute is radio. */
-  radiogroup: (value: string) => HTMLElements["menuitem"];
+  "radiogroup": (value: string) => BaseHTMLElements["menuitem"];
   /** This attribute indicates the kind of command, and can be one of three values. command: A regular command with an associated action. This is the missing value default. checkbox: Represents a command that can be toggled between two different states. radio: Represent one selection from a group of commands that can be toggled as radio buttons. */
-  type: (value: string) => HTMLElements["menuitem"];
-} & GlobalAriaAttributes<"menuitem"> &
-  GlobalHTMLAttributes<"menuitem">;
+  "type": (value: string) => BaseHTMLElements["menuitem"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<menuitemElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<menuitemElement>[key] } & { (...children: children): menuitemElement; };
 
 type metaElement = {
-  charset: (value: "utf-8") => HTMLElements["meta"];
-  content: (value: string) => HTMLElements["meta"];
-  httpEquiv: (
-    value:
-      | "content-type"
-      | "default-style"
-      | "refresh"
-      | "x-ua-compatible"
-      | "content-security-policy"
-  ) => HTMLElements["meta"];
-  media: (value: string) => HTMLElements["meta"];
-  name: (value: string) => HTMLElements["meta"];
-  role: (value: string) => HTMLElements["meta"];
-} & GlobalAriaAttributes<"meta"> &
-  GlobalHTMLAttributes<"meta">;
+  "charset": (value: "utf-8") => BaseHTMLElements["meta"];
+  "content": (value: string) => BaseHTMLElements["meta"];
+  "httpEquiv": (value: "content-type" | "default-style" | "refresh" | "x-ua-compatible" | "content-security-policy") => BaseHTMLElements["meta"];
+  "media": (value: string) => BaseHTMLElements["meta"];
+  "name": (value: string) => BaseHTMLElements["meta"];
+  "role": (value: string) => BaseHTMLElements["meta"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<metaElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<metaElement>[key] } & { (...children: children): metaElement; };
 
 type meterElement = {
   /** The <form> element to associate the <meter> element with (its form owner). The value of this attribute must be the id of a <form> in the same document. If this attribute is not set, the <meter> is associated with its ancestor <form> element, if any. This attribute is only used if the <meter> element is being used as a form-associated element, such as one displaying a range corresponding to an <input type="number">. */
-  form: (value: string) => HTMLElements["meter"];
-  high: (value: number) => HTMLElements["meter"];
-  low: (value: number) => HTMLElements["meter"];
-  max: (value: number) => HTMLElements["meter"];
-  min: (value: number) => HTMLElements["meter"];
-  optimum: (value: number) => HTMLElements["meter"];
-  role: (value: string) => HTMLElements["meter"];
-  value: (value: number) => HTMLElements["meter"];
-} & GlobalAriaAttributes<"meter"> &
-  GlobalHTMLAttributes<"meter">;
+  "form": (value: string) => BaseHTMLElements["meter"];
+  "high": (value: number) => BaseHTMLElements["meter"];
+  "low": (value: number) => BaseHTMLElements["meter"];
+  "max": (value: number) => BaseHTMLElements["meter"];
+  "min": (value: number) => BaseHTMLElements["meter"];
+  "optimum": (value: number) => BaseHTMLElements["meter"];
+  "role": (value: string) => BaseHTMLElements["meter"];
+  "value": (value: number) => BaseHTMLElements["meter"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<meterElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<meterElement>[key] } & { (...children: children): meterElement; };
 
-type multicolElement = {} & GlobalAriaAttributes<"multicol"> &
-  GlobalHTMLAttributes<"multicol">;
+type multicolElement = {
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<multicolElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<multicolElement>[key] } & { (...children: children): multicolElement; };
 
 type navElement = {
-  role: (value: string) => HTMLElements["nav"];
-} & GlobalAriaAttributes<"nav"> &
-  GlobalHTMLAttributes<"nav">;
+  "role": (value: string) => BaseHTMLElements["nav"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<navElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<navElement>[key] } & { (...children: children): navElement; };
 
-type nextidElement = {} & GlobalAriaAttributes<"nextid"> &
-  GlobalHTMLAttributes<"nextid">;
+type nextidElement = {
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<nextidElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<nextidElement>[key] } & { (...children: children): nextidElement; };
 
-type nobrElement = {} & GlobalAriaAttributes<"nobr"> &
-  GlobalHTMLAttributes<"nobr">;
+type nobrElement = {
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<nobrElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<nobrElement>[key] } & { (...children: children): nobrElement; };
 
-type noembedElement = {} & GlobalAriaAttributes<"noembed"> &
-  GlobalHTMLAttributes<"noembed">;
+type noembedElement = {
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<noembedElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<noembedElement>[key] } & { (...children: children): noembedElement; };
 
-type noframesElement = {} & GlobalAriaAttributes<"noframes"> &
-  GlobalHTMLAttributes<"noframes">;
+type noframesElement = {
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<noframesElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<noframesElement>[key] } & { (...children: children): noframesElement; };
 
 type noscriptElement = {
-  role: (value: string) => HTMLElements["noscript"];
-} & GlobalAriaAttributes<"noscript"> &
-  GlobalHTMLAttributes<"noscript">;
+  "role": (value: string) => BaseHTMLElements["noscript"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<noscriptElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<noscriptElement>[key] } & { (...children: children): noscriptElement; };
 
 type objectElement = {
   /** @deprecated A space-separated list of URIs for archives of resources for the object. */
-  archive: (value: string) => HTMLElements["object"];
+  "archive": (value: string) => BaseHTMLElements["object"];
   /** @deprecated The width of a border around the control, in pixels. */
-  border: (value: string) => HTMLElements["object"];
+  "border": (value: string) => BaseHTMLElements["object"];
   /** @deprecated The URI of the object's implementation. It can be used together with, or in place of, the data attribute. */
-  classid: (value: string) => HTMLElements["object"];
+  "classid": (value: string) => BaseHTMLElements["object"];
   /** @deprecated The base path used to resolve relative URIs specified by classid, data, or archive. If not specified, the default is the base URI of the current document. */
-  codebase: (value: string) => HTMLElements["object"];
+  "codebase": (value: string) => BaseHTMLElements["object"];
   /** @deprecated The content type of the data specified by classid. */
-  codetype: (value: string) => HTMLElements["object"];
-  data: (value: string) => HTMLElements["object"];
+  "codetype": (value: string) => BaseHTMLElements["object"];
+  "data": (value: string) => BaseHTMLElements["object"];
   /** @deprecated The presence of this Boolean attribute makes this element a declaration only. The object must be instantiated by a subsequent <object> element. In HTML5, repeat the <object> element completely each time that the resource is reused. */
-  declare: (value: string) => HTMLElements["object"];
+  "declare": (value: string) => BaseHTMLElements["object"];
   /** The form element, if any, that the object element is associated with (its form owner). The value of the attribute must be an ID of a <form> element in the same document. */
-  form: (value: string) => HTMLElements["object"];
+  "form": (value: string) => BaseHTMLElements["object"];
   /** The height of the displayed resource, in CSS pixels. -- (Absolute values only. NO percentages) */
-  height: (value: number) => HTMLElements["object"];
-  name: (value: string) => HTMLElements["object"];
-  role: (value: string) => HTMLElements["object"];
+  "height": (value: number) => BaseHTMLElements["object"];
+  "name": (value: string) => BaseHTMLElements["object"];
+  "role": (value: string) => BaseHTMLElements["object"];
   /** @deprecated A message that the browser can show while loading the object's implementation and data. */
-  standby: (value: string) => HTMLElements["object"];
-  type: (value: string) => HTMLElements["object"];
+  "standby": (value: string) => BaseHTMLElements["object"];
+  "type": (value: string) => BaseHTMLElements["object"];
   /** A hash-name reference to a <map> element; that is a '#' followed by the value of a name of a map element. */
-  usemap: (value: string) => HTMLElements["object"];
+  "usemap": (value: string) => BaseHTMLElements["object"];
   /** The width of the display resource, in CSS pixels. -- (Absolute values only. NO percentages) */
-  width: (value: number) => HTMLElements["object"];
-} & GlobalAriaAttributes<"object"> &
-  GlobalHTMLAttributes<"object">;
+  "width": (value: number) => BaseHTMLElements["object"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<objectElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<objectElement>[key] } & { (...children: children): objectElement; };
 
 type olElement = {
-  reversed: (value: boolean) => HTMLElements["ol"];
-  role: (value: string) => HTMLElements["ol"];
-  start: (value: string) => HTMLElements["ol"];
-  type: (value: "1" | "a" | "A" | "i" | "I") => HTMLElements["ol"];
-} & GlobalAriaAttributes<"ol"> &
-  GlobalHTMLAttributes<"ol">;
+  "reversed": (value: boolean) => BaseHTMLElements["ol"];
+  "role": (value: string) => BaseHTMLElements["ol"];
+  "start": (value: string) => BaseHTMLElements["ol"];
+  "type": (value: "1" | "a" | "A" | "i" | "I") => BaseHTMLElements["ol"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<olElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<olElement>[key] } & { (...children: children): olElement; };
 
 type optgroupElement = {
   /** If this Boolean attribute is set, none of the items in this option group is selectable. Often browsers grey out such control and it won't receive any browsing events, like mouse clicks or focus-related ones. */
-  disabled: (value: boolean) => HTMLElements["optgroup"];
-  label: (value: string) => HTMLElements["optgroup"];
-  role: (value: string) => HTMLElements["optgroup"];
-} & GlobalAriaAttributes<"optgroup"> &
-  GlobalHTMLAttributes<"optgroup">;
+  "disabled": (value: boolean) => BaseHTMLElements["optgroup"];
+  "label": (value: string) => BaseHTMLElements["optgroup"];
+  "role": (value: string) => BaseHTMLElements["optgroup"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<optgroupElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<optgroupElement>[key] } & { (...children: children): optgroupElement; };
 
 type optionElement = {
   /** If this Boolean attribute is set, this option is not checkable. Often browsers grey out such control and it won't receive any browsing event, like mouse clicks or focus-related ones. If this attribute is not set, the element can still be disabled if one of its ancestors is a disabled <optgroup> element. */
-  disabled: (value: boolean) => HTMLElements["option"];
-  label: (value: string) => HTMLElements["option"];
-  role: (value: string) => HTMLElements["option"];
-  selected: (value: boolean) => HTMLElements["option"];
-  value: (value: string) => HTMLElements["option"];
-} & GlobalAriaAttributes<"option"> &
-  GlobalHTMLAttributes<"option">;
+  "disabled": (value: boolean) => BaseHTMLElements["option"];
+  "label": (value: string) => BaseHTMLElements["option"];
+  "role": (value: string) => BaseHTMLElements["option"];
+  "selected": (value: boolean) => BaseHTMLElements["option"];
+  "value": (value: string) => BaseHTMLElements["option"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<optionElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<optionElement>[key] } & { (...children: children): optionElement; };
 
 type outputElement = {
-  for: (value: string) => HTMLElements["output"];
+  "for": (value: string) => BaseHTMLElements["output"];
   /** The <form> element to associate the output with (its form owner). The value of this attribute must be the id of a <form> in the same document. (If this attribute is not set, the <output> is associated with its ancestor <form> element, if any.) This attribute lets you associate <output> elements to <form>s anywhere in the document, not just inside a <form>. It can also override an ancestor <form> element. */
-  form: (value: string) => HTMLElements["output"];
+  "form": (value: string) => BaseHTMLElements["output"];
   /** The element's name. Used in the form.elements API. */
-  name: (value: string) => HTMLElements["output"];
-  role: (value: string) => HTMLElements["output"];
-} & GlobalAriaAttributes<"output"> &
-  GlobalHTMLAttributes<"output">;
+  "name": (value: string) => BaseHTMLElements["output"];
+  "role": (value: string) => BaseHTMLElements["output"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<outputElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<outputElement>[key] } & { (...children: children): outputElement; };
 
 type pElement = {
-  role: (value: string) => HTMLElements["p"];
-} & GlobalAriaAttributes<"p"> &
-  GlobalHTMLAttributes<"p">;
+  "role": (value: string) => BaseHTMLElements["p"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<pElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<pElement>[key] } & { (...children: children): pElement; };
 
 type paramElement = {
-  name: (value: string) => HTMLElements["param"];
-  role: (value: string) => HTMLElements["param"];
+  "name": (value: string) => BaseHTMLElements["param"];
+  "role": (value: string) => BaseHTMLElements["param"];
   /** @deprecated Only used if the valuetype is set to ref. Specifies the MIME type of values found at the URI specified by value. */
-  type: (value: string) => HTMLElements["param"];
-  value: (value: string) => HTMLElements["param"];
+  "type": (value: string) => BaseHTMLElements["param"];
+  "value": (value: string) => BaseHTMLElements["param"];
   /** @deprecated Specifies the type of the value attribute. Possible values are: data: Default value. The value is passed to the object's implementation as a string. ref: The value is a URI to a resource where run-time values are stored. object: An ID of another <object> in the same document. */
-  valuetype: (value: string) => HTMLElements["param"];
-} & GlobalAriaAttributes<"param"> &
-  GlobalHTMLAttributes<"param">;
+  "valuetype": (value: string) => BaseHTMLElements["param"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<paramElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<paramElement>[key] } & { (...children: children): paramElement; };
 
 type pictureElement = {
-  role: (value: string) => HTMLElements["picture"];
-} & GlobalAriaAttributes<"picture"> &
-  GlobalHTMLAttributes<"picture">;
+  "role": (value: string) => BaseHTMLElements["picture"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<pictureElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<pictureElement>[key] } & { (...children: children): pictureElement; };
 
-type plaintextElement = {} & GlobalAriaAttributes<"plaintext"> &
-  GlobalHTMLAttributes<"plaintext">;
+type plaintextElement = {
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<plaintextElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<plaintextElement>[key] } & { (...children: children): plaintextElement; };
 
 type portalElement = {
-  referrerpolicy: (
-    value:
-      | ""
-      | "no-referrer"
-      | "no-referrer-when-downgrade"
-      | "same-origin"
-      | "origin"
-      | "strict-origin"
-      | "origin-when-cross-origin"
-      | "strict-origin-when-cross-origin"
-      | "unsafe-url"
-  ) => HTMLElements["portal"];
-  role: (value: string) => HTMLElements["portal"];
-  src: (value: string) => HTMLElements["portal"];
-} & GlobalAriaAttributes<"portal"> &
-  GlobalHTMLAttributes<"portal">;
+  "referrerpolicy": (value: "" | "no-referrer" | "no-referrer-when-downgrade" | "same-origin" | "origin" | "strict-origin" | "origin-when-cross-origin" | "strict-origin-when-cross-origin" | "unsafe-url") => BaseHTMLElements["portal"];
+  "role": (value: string) => BaseHTMLElements["portal"];
+  "src": (value: string) => BaseHTMLElements["portal"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<portalElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<portalElement>[key] } & { (...children: children): portalElement; };
 
 type preElement = {
   /** @deprecated Contains the preferred count of characters that a line should have. It was a non-standard synonym of width. To achieve such an effect, use CSS width instead. */
-  cols: (value: string) => HTMLElements["pre"];
-  role: (value: string) => HTMLElements["pre"];
+  "cols": (value: string) => BaseHTMLElements["pre"];
+  "role": (value: string) => BaseHTMLElements["pre"];
   /** @deprecated Contains the preferred count of characters that a line should have. Though technically still implemented, this attribute has no visual effect; to achieve such an effect, use CSS width instead. */
-  width: (value: string) => HTMLElements["pre"];
+  "width": (value: string) => BaseHTMLElements["pre"];
   /** Is a hint indicating how the overflow must happen. In modern browser this hint is ignored and no visual effect results in its present; to achieve such an effect, use CSS white-space instead. */
-  wrap: (value: string) => HTMLElements["pre"];
-} & GlobalAriaAttributes<"pre"> &
-  GlobalHTMLAttributes<"pre">;
+  "wrap": (value: string) => BaseHTMLElements["pre"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<preElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<preElement>[key] } & { (...children: children): preElement; };
 
 type progressElement = {
-  max: (value: number) => HTMLElements["progress"];
-  role: (value: string) => HTMLElements["progress"];
-  value: (value: number) => HTMLElements["progress"];
-} & GlobalAriaAttributes<"progress"> &
-  GlobalHTMLAttributes<"progress">;
+  "max": (value: number) => BaseHTMLElements["progress"];
+  "role": (value: string) => BaseHTMLElements["progress"];
+  "value": (value: number) => BaseHTMLElements["progress"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<progressElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<progressElement>[key] } & { (...children: children): progressElement; };
 
 type qElement = {
-  cite: (value: string) => HTMLElements["q"];
-  role: (value: string) => HTMLElements["q"];
-} & GlobalAriaAttributes<"q"> &
-  GlobalHTMLAttributes<"q">;
+  "cite": (value: string) => BaseHTMLElements["q"];
+  "role": (value: string) => BaseHTMLElements["q"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<qElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<qElement>[key] } & { (...children: children): qElement; };
 
-type rbElement = {} & GlobalAriaAttributes<"rb"> & GlobalHTMLAttributes<"rb">;
+type rbElement = {
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<rbElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<rbElement>[key] } & { (...children: children): rbElement; };
 
 type rpElement = {
-  role: (value: string) => HTMLElements["rp"];
-} & GlobalAriaAttributes<"rp"> &
-  GlobalHTMLAttributes<"rp">;
+  "role": (value: string) => BaseHTMLElements["rp"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<rpElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<rpElement>[key] } & { (...children: children): rpElement; };
 
 type rtElement = {
-  role: (value: string) => HTMLElements["rt"];
-} & GlobalAriaAttributes<"rt"> &
-  GlobalHTMLAttributes<"rt">;
+  "role": (value: string) => BaseHTMLElements["rt"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<rtElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<rtElement>[key] } & { (...children: children): rtElement; };
 
-type rtcElement = {} & GlobalAriaAttributes<"rtc"> &
-  GlobalHTMLAttributes<"rtc">;
+type rtcElement = {
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<rtcElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<rtcElement>[key] } & { (...children: children): rtcElement; };
 
 type rubyElement = {
-  role: (value: string) => HTMLElements["ruby"];
-} & GlobalAriaAttributes<"ruby"> &
-  GlobalHTMLAttributes<"ruby">;
+  "role": (value: string) => BaseHTMLElements["ruby"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<rubyElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<rubyElement>[key] } & { (...children: children): rubyElement; };
 
 type sElement = {
-  role: (value: string) => HTMLElements["s"];
-} & GlobalAriaAttributes<"s"> &
-  GlobalHTMLAttributes<"s">;
+  "role": (value: string) => BaseHTMLElements["s"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<sElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<sElement>[key] } & { (...children: children): sElement; };
 
 type sampElement = {
-  role: (value: string) => HTMLElements["samp"];
-} & GlobalAriaAttributes<"samp"> &
-  GlobalHTMLAttributes<"samp">;
+  "role": (value: string) => BaseHTMLElements["samp"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<sampElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<sampElement>[key] } & { (...children: children): sampElement; };
 
 type scriptElement = {
-  async: (value: boolean) => HTMLElements["script"];
-  blocking: (value: "render") => HTMLElements["script"];
+  "async": (value: boolean) => BaseHTMLElements["script"];
+  "blocking": (value: "render") => BaseHTMLElements["script"];
   /** @deprecated If present, its value must be an ASCII case-insensitive match for "utf-8". It's unnecessary to specify the charset attribute, because documents must use UTF-8, and the script element inherits its character encoding from the document. */
-  charset: (value: string) => HTMLElements["script"];
+  "charset": (value: string) => BaseHTMLElements["script"];
   /** Normal script elements pass minimal information to the window.onerror for scripts which do not pass the standard CORS checks. To allow error logging for sites which use a separate domain for static media, use this attribute. See CORS settings attributes for a more descriptive explanation of its valid arguments. */
-  crossorigin: (
-    value: "" | "anonymous" | "use-credentials"
-  ) => HTMLElements["script"];
-  defer: (value: boolean) => HTMLElements["script"];
-  integrity: (value: string) => HTMLElements["script"];
+  "crossorigin": (value: "" | "anonymous" | "use-credentials") => BaseHTMLElements["script"];
+  "defer": (value: boolean) => BaseHTMLElements["script"];
+  "integrity": (value: string) => BaseHTMLElements["script"];
   /** @deprecated Like the type attribute, this attribute identifies the scripting language in use. Unlike the type attribute, however, this attribute's possible values were never standardized. The type attribute should be used instead. */
-  language: (value: string) => HTMLElements["script"];
-  nomodule: (value: boolean) => HTMLElements["script"];
+  "language": (value: string) => BaseHTMLElements["script"];
+  "nomodule": (value: boolean) => BaseHTMLElements["script"];
   /** Indicates which referrer to send when fetching the script, or resources fetched by the script: no-referrer: The Referer header will not be sent. no-referrer-when-downgrade: The Referer header will not be sent to origins without TLS (HTTPS). origin: The sent referrer will be limited to the origin of the referring page: its scheme, host, and port. origin-when-cross-origin: The referrer sent to other origins will be limited to the scheme, the host, and the port. Navigations on the same origin will still include the path. same-origin: A referrer will be sent for same origin, but cross-origin requests will contain no referrer information. strict-origin: Only send the origin of the document as the referrer when the protocol security level stays the same (HTTPS→HTTPS), but don't send it to a less secure destination (HTTPS→HTTP). strict-origin-when-cross-origin (default): Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP). unsafe-url: The referrer will include the origin and the path (but not the fragment, password, or username). This value is unsafe, because it leaks origins and paths from TLS-protected resources to insecure origins. Note: An empty string value ("") is both the default value, and a fallback value if referrerpolicy is not supported. If referrerpolicy is not explicitly specified on the <script> element, it will adopt a higher-level referrer policy, i.e. one set on the whole document or domain. If a higher-level policy is not available, the empty string is treated as being equivalent to strict-origin-when-cross-origin. */
-  referrerpolicy: (
-    value:
-      | ""
-      | "no-referrer"
-      | "no-referrer-when-downgrade"
-      | "same-origin"
-      | "origin"
-      | "strict-origin"
-      | "origin-when-cross-origin"
-      | "strict-origin-when-cross-origin"
-      | "unsafe-url"
-  ) => HTMLElements["script"];
-  role: (value: string) => HTMLElements["script"];
-  src: (value: string) => HTMLElements["script"];
-  type: (value: string) => HTMLElements["script"];
-} & GlobalAriaAttributes<"script"> &
-  GlobalHTMLAttributes<"script">;
+  "referrerpolicy": (value: "" | "no-referrer" | "no-referrer-when-downgrade" | "same-origin" | "origin" | "strict-origin" | "origin-when-cross-origin" | "strict-origin-when-cross-origin" | "unsafe-url") => BaseHTMLElements["script"];
+  "role": (value: string) => BaseHTMLElements["script"];
+  "src": (value: string) => BaseHTMLElements["script"];
+  "type": (value: string) => BaseHTMLElements["script"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<scriptElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<scriptElement>[key] } & { (...children: children): scriptElement; };
 
 type sectionElement = {
-  role: (value: string) => HTMLElements["section"];
-} & GlobalAriaAttributes<"section"> &
-  GlobalHTMLAttributes<"section">;
+  "role": (value: string) => BaseHTMLElements["section"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<sectionElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<sectionElement>[key] } & { (...children: children): sectionElement; };
 
 type selectElement = {
   /** A DOMString providing a hint for a user agent's autocomplete feature. See The HTML autocomplete attribute for a complete list of values and details on how to use autocomplete. */
-  autocomplete: (value: string) => HTMLElements["select"];
+  "autocomplete": (value: string) => BaseHTMLElements["select"];
   /** This Boolean attribute indicates that the user cannot interact with the control. If this attribute is not specified, the control inherits its setting from the containing element, for example <fieldset>; if there is no containing element with the disabled attribute set, then the control is enabled. */
-  disabled: (value: boolean) => HTMLElements["select"];
+  "disabled": (value: boolean) => BaseHTMLElements["select"];
   /** The <form> element to associate the <select> with (its form owner). The value of this attribute must be the id of a <form> in the same document. (If this attribute is not set, the <select> is associated with its ancestor <form> element, if any.) This attribute lets you associate <select> elements to <form>s anywhere in the document, not just inside a <form>. It can also override an ancestor <form> element. */
-  form: (value: string) => HTMLElements["select"];
-  multiple: (value: boolean) => HTMLElements["select"];
+  "form": (value: string) => BaseHTMLElements["select"];
+  "multiple": (value: boolean) => BaseHTMLElements["select"];
   /** This attribute is used to specify the name of the control. */
-  name: (value: string) => HTMLElements["select"];
+  "name": (value: string) => BaseHTMLElements["select"];
   /** A Boolean attribute indicating that an option with a non-empty string value must be selected. */
-  required: (value: boolean) => HTMLElements["select"];
-  role: (value: string) => HTMLElements["select"];
-  size: (value: string) => HTMLElements["select"];
-} & GlobalAriaAttributes<"select"> &
-  GlobalHTMLAttributes<"select">;
+  "required": (value: boolean) => BaseHTMLElements["select"];
+  "role": (value: string) => BaseHTMLElements["select"];
+  "size": (value: string) => BaseHTMLElements["select"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<selectElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<selectElement>[key] } & { (...children: children): selectElement; };
 
-type shadowElement = {} & GlobalAriaAttributes<"shadow"> &
-  GlobalHTMLAttributes<"shadow">;
+type shadowElement = {
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<shadowElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<shadowElement>[key] } & { (...children: children): shadowElement; };
 
 type slotElement = {
-  name: (value: string) => HTMLElements["slot"];
-  role: (value: string) => HTMLElements["slot"];
-} & GlobalAriaAttributes<"slot"> &
-  GlobalHTMLAttributes<"slot">;
+  "name": (value: string) => BaseHTMLElements["slot"];
+  "role": (value: string) => BaseHTMLElements["slot"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<slotElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<slotElement>[key] } & { (...children: children): slotElement; };
 
 type smallElement = {
-  role: (value: string) => HTMLElements["small"];
-} & GlobalAriaAttributes<"small"> &
-  GlobalHTMLAttributes<"small">;
+  "role": (value: string) => BaseHTMLElements["small"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<smallElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<smallElement>[key] } & { (...children: children): smallElement; };
 
 type sourceElement = {
-  height: (value: number) => HTMLElements["source"];
-  media: (value: string) => HTMLElements["source"];
-  role: (value: string) => HTMLElements["source"];
-  sizes: (value: string) => HTMLElements["source"];
-  src: (value: string) => HTMLElements["source"];
-  srcset: (value: string) => HTMLElements["source"];
-  type: (value: string) => HTMLElements["source"];
-  width: (value: number) => HTMLElements["source"];
-} & GlobalAriaAttributes<"source"> &
-  GlobalHTMLAttributes<"source">;
+  "height": (value: number) => BaseHTMLElements["source"];
+  "media": (value: string) => BaseHTMLElements["source"];
+  "role": (value: string) => BaseHTMLElements["source"];
+  "sizes": (value: string) => BaseHTMLElements["source"];
+  "src": (value: string) => BaseHTMLElements["source"];
+  "srcset": (value: string) => BaseHTMLElements["source"];
+  "type": (value: string) => BaseHTMLElements["source"];
+  "width": (value: number) => BaseHTMLElements["source"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<sourceElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<sourceElement>[key] } & { (...children: children): sourceElement; };
 
 type spacerElement = {
   /** This attribute determines alignment of spacer. Possible values are left, right and center. */
-  align: (value: string) => HTMLElements["spacer"];
+  "align": (value: string) => BaseHTMLElements["spacer"];
   /** This attribute can be used for defining height of spacer in pixels when type is block. */
-  height: (value: string) => HTMLElements["spacer"];
+  "height": (value: string) => BaseHTMLElements["spacer"];
   /** This attribute can be used for defining size of spacer in pixels when type is horizontal or vertical. */
-  size: (value: string) => HTMLElements["spacer"];
+  "size": (value: string) => BaseHTMLElements["spacer"];
   /** This attribute determines type of spacer. Possible values are horizontal, vertical and block. */
-  type: (value: string) => HTMLElements["spacer"];
+  "type": (value: string) => BaseHTMLElements["spacer"];
   /** This attribute can be used for defining width of spacer in pixels when type is block. */
-  width: (value: string) => HTMLElements["spacer"];
-} & GlobalAriaAttributes<"spacer"> &
-  GlobalHTMLAttributes<"spacer">;
+  "width": (value: string) => BaseHTMLElements["spacer"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<spacerElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<spacerElement>[key] } & { (...children: children): spacerElement; };
 
 type spanElement = {
-  role: (value: string) => HTMLElements["span"];
-} & GlobalAriaAttributes<"span"> &
-  GlobalHTMLAttributes<"span">;
+  "role": (value: string) => BaseHTMLElements["span"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<spanElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<spanElement>[key] } & { (...children: children): spanElement; };
 
-type strikeElement = {} & GlobalAriaAttributes<"strike"> &
-  GlobalHTMLAttributes<"strike">;
+type strikeElement = {
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<strikeElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<strikeElement>[key] } & { (...children: children): strikeElement; };
 
 type strongElement = {
-  role: (value: string) => HTMLElements["strong"];
-} & GlobalAriaAttributes<"strong"> &
-  GlobalHTMLAttributes<"strong">;
+  "role": (value: string) => BaseHTMLElements["strong"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<strongElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<strongElement>[key] } & { (...children: children): strongElement; };
 
 type styleElement = {
-  blocking: (value: "render") => HTMLElements["style"];
-  media: (value: string) => HTMLElements["style"];
-  role: (value: string) => HTMLElements["style"];
+  "blocking": (value: "render") => BaseHTMLElements["style"];
+  "media": (value: string) => BaseHTMLElements["style"];
+  "role": (value: string) => BaseHTMLElements["style"];
   /** @deprecated This attribute specifies that the styles only apply to the elements of its parent(s) and children. Note: This attribute may be re-introduced in the future per https://github.com/w3c/csswg-drafts/issues/3547. If you want to use the attribute now, you can use a polyfill. */
-  scoped: (value: string) => HTMLElements["style"];
+  "scoped": (value: string) => BaseHTMLElements["style"];
   /** @deprecated This attribute should not be provided: if it is, the only permitted values are the empty string or a case-insensitive match for text/css. */
-  type: (value: string) => HTMLElements["style"];
-} & GlobalAriaAttributes<"style"> &
-  GlobalHTMLAttributes<"style">;
+  "type": (value: string) => BaseHTMLElements["style"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<styleElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<styleElement>[key] } & { (...children: children): styleElement; };
 
 type subElement = {
-  role: (value: string) => HTMLElements["sub"];
-} & GlobalAriaAttributes<"sub"> &
-  GlobalHTMLAttributes<"sub">;
+  "role": (value: string) => BaseHTMLElements["sub"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<subElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<subElement>[key] } & { (...children: children): subElement; };
 
 type summaryElement = {
-  role: (value: string) => HTMLElements["summary"];
-} & GlobalAriaAttributes<"summary"> &
-  GlobalHTMLAttributes<"summary">;
+  "role": (value: string) => BaseHTMLElements["summary"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<summaryElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<summaryElement>[key] } & { (...children: children): summaryElement; };
 
 type supElement = {
-  role: (value: string) => HTMLElements["sup"];
-} & GlobalAriaAttributes<"sup"> &
-  GlobalHTMLAttributes<"sup">;
+  "role": (value: string) => BaseHTMLElements["sup"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<supElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<supElement>[key] } & { (...children: children): supElement; };
 
 type tableElement = {
   /** @deprecated This enumerated attribute indicates how the table must be aligned inside the containing document. It may have the following values: left: the table is displayed on the left side of the document; center: the table is displayed in the center of the document; right: the table is displayed on the right side of the document. Set margin-left and margin-right to auto or margin to 0 auto to achieve an effect that is similar to the align attribute. */
-  align: (value: string) => HTMLElements["table"];
+  "align": (value: string) => BaseHTMLElements["table"];
   /** @deprecated The background color of the table. It is a 6-digit hexadecimal RGB code, prefixed by a '#'. One of the predefined color keywords can also be used. To achieve a similar effect, use the CSS background-color property. */
-  bgcolor: (value: string) => HTMLElements["table"];
+  "bgcolor": (value: string) => BaseHTMLElements["table"];
   /** @deprecated This integer attribute defines, in pixels, the size of the frame surrounding the table. If set to 0, the frame attribute is set to void. To achieve a similar effect, use the CSS border shorthand property. */
-  border: (value: string) => HTMLElements["table"];
+  "border": (value: string) => BaseHTMLElements["table"];
   /** @deprecated This attribute defines the space between the content of a cell and its border, displayed or not. If the cellpadding's length is defined in pixels, this pixel-sized space will be applied to all four sides of the cell's content. If the length is defined using a percentage value, the content will be centered and the total vertical space (top and bottom) will represent this value. The same is true for the total horizontal space (left and right). To achieve a similar effect, apply the border-collapse property to the <table> element, with its value set to collapse, and the padding property to the <td> elements. */
-  cellpadding: (value: string) => HTMLElements["table"];
+  "cellpadding": (value: string) => BaseHTMLElements["table"];
   /** @deprecated This attribute defines the size of the space between two cells in a percentage value or pixels. The attribute is applied both horizontally and vertically, to the space between the top of the table and the cells of the first row, the left of the table and the first column, the right of the table and the last column and the bottom of the table and the last row. To achieve a similar effect, apply the border-spacing property to the <table> element. border-spacing does not have any effect if border-collapse is set to collapse. */
-  cellspacing: (value: string) => HTMLElements["table"];
+  "cellspacing": (value: string) => BaseHTMLElements["table"];
   /** @deprecated This enumerated attribute defines which side of the frame surrounding the table must be displayed. To achieve a similar effect, use the border-style and border-width properties. */
-  frame: (value: string) => HTMLElements["table"];
-  role: (value: string) => HTMLElements["table"];
+  "frame": (value: string) => BaseHTMLElements["table"];
+  "role": (value: string) => BaseHTMLElements["table"];
   /** @deprecated This enumerated attribute defines where rules, i.e. lines, should appear in a table. It can have the following values: none, which indicates that no rules will be displayed; it is the default value; groups, which will cause the rules to be displayed between row groups (defined by the <thead>, <tbody> and <tfoot> elements) and between column groups (defined by the <col> and <colgroup> elements) only; rows, which will cause the rules to be displayed between rows; columns, which will cause the rules to be displayed between columns; all, which will cause the rules to be displayed between rows and columns. To achieve a similar effect, apply the border property to the appropriate <thead>, <tbody>, <tfoot>, <col>, or <colgroup> elements. */
-  rules: (value: string) => HTMLElements["table"];
+  "rules": (value: string) => BaseHTMLElements["table"];
   /** @deprecated This attribute defines an alternative text that summarizes the content of the table. Use the <caption> element instead. */
-  summary: (value: string) => HTMLElements["table"];
+  "summary": (value: string) => BaseHTMLElements["table"];
   /** @deprecated This attribute defines the width of the table. Use the CSS width property instead. */
-  width: (value: string) => HTMLElements["table"];
-} & GlobalAriaAttributes<"table"> &
-  GlobalHTMLAttributes<"table">;
+  "width": (value: string) => BaseHTMLElements["table"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<tableElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<tableElement>[key] } & { (...children: children): tableElement; };
 
 type tbodyElement = {
   /** @deprecated This enumerated attribute specifies how horizontal alignment of each cell content will be handled. Possible values are: left, aligning the content to the left of the cell center, centering the content in the cell right, aligning the content to the right of the cell justify, inserting spaces into the textual content so that the content is justified in the cell char, aligning the textual content on a special character with a minimal offset, defined by the char and charoff attributes. If this attribute is not set, the left value is assumed. As this attribute is deprecated, use the CSS text-align property instead. Note: The equivalent text-align property for the align="char" is not implemented in any browsers yet. See the text-align's browser compatibility section for the <string> value. */
-  align: (value: string) => HTMLElements["tbody"];
+  "align": (value: string) => BaseHTMLElements["tbody"];
   /** @deprecated The background color of the table. It is a 6-digit hexadecimal RGB code, prefixed by a '#'. One of the predefined color keywords can also be used. As this attribute is deprecated, use the CSS background-color property instead. */
-  bgcolor: (value: string) => HTMLElements["tbody"];
+  "bgcolor": (value: string) => BaseHTMLElements["tbody"];
   /** @deprecated This attribute is used to set the character to align the cells in a column on. Typical values for this include a period (.) when attempting to align numbers or monetary values. If align is not set to char, this attribute is ignored. */
-  char: (value: string) => HTMLElements["tbody"];
+  "char": (value: string) => BaseHTMLElements["tbody"];
   /** @deprecated This attribute is used to indicate the number of characters to offset the column data from the alignment characters specified by the char attribute. */
-  charoff: (value: string) => HTMLElements["tbody"];
-  role: (value: string) => HTMLElements["tbody"];
+  "charoff": (value: string) => BaseHTMLElements["tbody"];
+  "role": (value: string) => BaseHTMLElements["tbody"];
   /** @deprecated This attribute specifies the vertical alignment of the text within each row of cells of the table header. Possible values for this attribute are: baseline, which will put the text as close to the bottom of the cell as it is possible, but align it on the baseline of the characters instead of the bottom of them. If characters are all of the size, this has the same effect as bottom. bottom, which will put the text as close to the bottom of the cell as it is possible; middle, which will center the text in the cell; and top, which will put the text as close to the top of the cell as it is possible. As this attribute is deprecated, use the CSS vertical-align property instead. */
-  valign: (value: string) => HTMLElements["tbody"];
-} & GlobalAriaAttributes<"tbody"> &
-  GlobalHTMLAttributes<"tbody">;
+  "valign": (value: string) => BaseHTMLElements["tbody"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<tbodyElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<tbodyElement>[key] } & { (...children: children): tbodyElement; };
 
 type tdElement = {
   /** @deprecated This attribute contains a short abbreviated description of the cell's content. Some user-agents, such as speech readers, may present this description before the content itself. Note: Do not use this attribute as it is obsolete in the latest standard. Alternatively, you can put the abbreviated description inside the cell and place the long content in the title attribute. */
-  abbr: (value: string) => HTMLElements["td"];
+  "abbr": (value: string) => BaseHTMLElements["td"];
   /** @deprecated This enumerated attribute specifies how the cell content's horizontal alignment will be handled. Possible values are: left: The content is aligned to the left of the cell. center: The content is centered in the cell. right: The content is aligned to the right of the cell. justify (with text only): The content is stretched out inside the cell so that it covers its entire width. char (with text only): The content is aligned to a character inside the <th> element with minimal offset. This character is defined by the char and charoff attributes Unimplemented (see bug 2212). The default value when this attribute is not specified is left. Note: To achieve the same effect as the left, center, right or justify values, apply the CSS text-align property to the element. To achieve the same effect as the char value, give the text-align property the same value you would use for the char. Unimplemented in CSS3. */
-  align: (value: string) => HTMLElements["td"];
+  "align": (value: string) => BaseHTMLElements["td"];
   /** @deprecated This attribute contains a list of space-separated strings. Each string is the id of a group of cells that this header applies to. */
-  axis: (value: string) => HTMLElements["td"];
+  "axis": (value: string) => BaseHTMLElements["td"];
   /** @deprecated This attribute defines the background color of each cell in a column. It is a 6-digit hexadecimal RGB code, prefixed by a '#'. One of the predefined color keywords can also be used. To achieve a similar effect, use the CSS background-color property. */
-  bgcolor: (value: string) => HTMLElements["td"];
+  "bgcolor": (value: string) => BaseHTMLElements["td"];
   /** @deprecated The content in the cell element is aligned to a character. Typical values include a period (.) to align numbers or monetary values. If align is not set to char, this attribute is ignored. */
-  char: (value: string) => HTMLElements["td"];
+  "char": (value: string) => BaseHTMLElements["td"];
   /** @deprecated This attribute is used to shift column data to the right of the character specified by the char attribute. Its value specifies the length of this shift. */
-  charoff: (value: string) => HTMLElements["td"];
+  "charoff": (value: string) => BaseHTMLElements["td"];
   /** This attribute contains a non-negative integer value that indicates for how many columns the cell extends. Its default value is 1. Values higher than 1000 will be considered as incorrect and will be set to the default value (1). */
-  colspan: (value: string) => HTMLElements["td"];
+  "colspan": (value: string) => BaseHTMLElements["td"];
   /** This attribute contains a list of space-separated strings, each corresponding to the id attribute of the <th> elements that apply to this element. */
-  headers: (value: string) => HTMLElements["td"];
+  "headers": (value: string) => BaseHTMLElements["td"];
   /** @deprecated This attribute is used to define a recommended cell height. Use the CSS height property instead. */
-  height: (value: string) => HTMLElements["td"];
-  role: (value: string) => HTMLElements["td"];
+  "height": (value: string) => BaseHTMLElements["td"];
+  "role": (value: string) => BaseHTMLElements["td"];
   /** This attribute contains a non-negative integer value that indicates for how many rows the cell extends. Its default value is 1; if its value is set to 0, it extends until the end of the table section (<thead>, <tbody>, <tfoot>, even if implicitly defined), that the cell belongs to. Values higher than 65534 are clipped down to 65534. */
-  rowspan: (value: string) => HTMLElements["td"];
+  "rowspan": (value: string) => BaseHTMLElements["td"];
   /** @deprecated This enumerated attribute defines the cells that the header (defined in the <th>) element relates to. Only use this attribute with the <th> element to define the row or column for which it is a header. */
-  scope: (value: string) => HTMLElements["td"];
+  "scope": (value: string) => BaseHTMLElements["td"];
   /** @deprecated This attribute specifies how a text is vertically aligned inside a cell. Possible values for this attribute are: baseline: Positions the text near the bottom of the cell and aligns it with the baseline of the characters instead of the bottom. If characters don't descend below the baseline, the baseline value achieves the same effect as bottom. bottom: Positions the text near the bottom of the cell. middle: Centers the text in the cell. and top: Positions the text near the top of the cell. To achieve a similar effect, use the CSS vertical-align property. */
-  valign: (value: string) => HTMLElements["td"];
+  "valign": (value: string) => BaseHTMLElements["td"];
   /** @deprecated This attribute is used to define a recommended cell width. Use the CSS width property instead. */
-  width: (value: string) => HTMLElements["td"];
-} & GlobalAriaAttributes<"td"> &
-  GlobalHTMLAttributes<"td">;
+  "width": (value: string) => BaseHTMLElements["td"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<tdElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<tdElement>[key] } & { (...children: children): tdElement; };
 
 type templateElement = {
-  role: (value: string) => HTMLElements["template"];
-} & GlobalAriaAttributes<"template"> &
-  GlobalHTMLAttributes<"template">;
+  "role": (value: string) => BaseHTMLElements["template"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<templateElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<templateElement>[key] } & { (...children: children): templateElement; };
 
 type textareaElement = {
   /** This attribute indicates whether the value of the control can be automatically completed by the browser. Possible values are: off: The user must explicitly enter a value into this field for every use, or the document provides its own auto-completion method; the browser does not automatically complete the entry. on: The browser can automatically complete the value based on values that the user has entered during previous uses. If the autocomplete attribute is not specified on a <textarea> element, then the browser uses the autocomplete attribute value of the <textarea> element's form owner. The form owner is either the <form> element that this <textarea> element is a descendant of or the form element whose id is specified by the form attribute of the input element. For more information, see the autocomplete attribute in <form>. */
-  autocomplete: (value: string) => HTMLElements["textarea"];
+  "autocomplete": (value: string) => BaseHTMLElements["textarea"];
   /** A string which indicates whether or not to activate automatic spelling correction and processing of text substitutions (if any are configured) while the user is editing this textarea. Permitted values are: on Enable automatic spelling correction and text substitutions. off Disable automatic spelling correction and text substitutions. */
-  autocorrect: (value: string) => HTMLElements["textarea"];
-  cols: (value: string) => HTMLElements["textarea"];
-  dirname: (value: string) => HTMLElements["textarea"];
+  "autocorrect": (value: string) => BaseHTMLElements["textarea"];
+  "cols": (value: string) => BaseHTMLElements["textarea"];
+  "dirname": (value: string) => BaseHTMLElements["textarea"];
   /** This Boolean attribute indicates that the user cannot interact with the control. If this attribute is not specified, the control inherits its setting from the containing element, for example <fieldset>; if there is no containing element when the disabled attribute is set, the control is enabled. */
-  disabled: (value: boolean) => HTMLElements["textarea"];
+  "disabled": (value: boolean) => BaseHTMLElements["textarea"];
   /** The form element that the <textarea> element is associated with (its "form owner"). The value of the attribute must be the id of a form element in the same document. If this attribute is not specified, the <textarea> element must be a descendant of a form element. This attribute enables you to place <textarea> elements anywhere within a document, not just as descendants of form elements. */
-  form: (value: string) => HTMLElements["textarea"];
+  "form": (value: string) => BaseHTMLElements["textarea"];
   /** The maximum number of characters (UTF-16 code units) that the user can enter. If this value isn't specified, the user can enter an unlimited number of characters. */
-  maxlength: (value: number) => HTMLElements["textarea"];
+  "maxlength": (value: number) => BaseHTMLElements["textarea"];
   /** The minimum number of characters (UTF-16 code units) required that the user should enter. */
-  minlength: (value: number) => HTMLElements["textarea"];
+  "minlength": (value: number) => BaseHTMLElements["textarea"];
   /** The name of the control. */
-  name: (value: string) => HTMLElements["textarea"];
-  placeholder: (value: string) => HTMLElements["textarea"];
+  "name": (value: string) => BaseHTMLElements["textarea"];
+  "placeholder": (value: string) => BaseHTMLElements["textarea"];
   /** This Boolean attribute indicates that the user cannot modify the value of the control. Unlike the disabled attribute, the readonly attribute does not prevent the user from clicking or selecting in the control. The value of a read-only control is still submitted with the form. */
-  readonly: (value: boolean) => HTMLElements["textarea"];
+  "readonly": (value: boolean) => BaseHTMLElements["textarea"];
   /** This attribute specifies that the user must fill in a value before submitting a form. */
-  required: (value: boolean) => HTMLElements["textarea"];
-  role: (value: string) => HTMLElements["textarea"];
-  rows: (value: string) => HTMLElements["textarea"];
-  wrap: (value: "soft" | "hard") => HTMLElements["textarea"];
-} & GlobalAriaAttributes<"textarea"> &
-  GlobalHTMLAttributes<"textarea">;
+  "required": (value: boolean) => BaseHTMLElements["textarea"];
+  "role": (value: string) => BaseHTMLElements["textarea"];
+  "rows": (value: string) => BaseHTMLElements["textarea"];
+  "wrap": (value: "soft" | "hard") => BaseHTMLElements["textarea"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<textareaElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<textareaElement>[key] } & { (...children: children): textareaElement; };
 
 type tfootElement = {
   /** @deprecated This enumerated attribute specifies how horizontal alignment of each cell content will be handled. Possible values are: left, aligning the content to the left of the cell center, centering the content in the cell right, aligning the content to the right of the cell justify, inserting spaces into the textual content so that the content is justified in the cell char, aligning the textual content on a special character with a minimal offset, defined by the char and charoff attributes. If this attribute is not set, the left value is assumed. Note: To achieve the same effect as the left, center, right or justify values, use the CSS text-align property on it. To achieve the same effect as the char value, in CSS3, you can use the value of the char as the value of the text-align property Unimplemented. */
-  align: (value: string) => HTMLElements["tfoot"];
+  "align": (value: string) => BaseHTMLElements["tfoot"];
   /** @deprecated The background color of the table. It is a 6-digit hexadecimal RGB code, prefixed by a '#'. One of the predefined color keywords can also be used. To achieve a similar effect, use the CSS background-color property. */
-  bgcolor: (value: string) => HTMLElements["tfoot"];
+  "bgcolor": (value: string) => BaseHTMLElements["tfoot"];
   /** @deprecated This attribute specifies the alignment of the content in a column to a character. Typical values for this include a period (.) when attempting to align numbers or monetary values. If align is not set to char, this attribute is ignored. */
-  char: (value: string) => HTMLElements["tfoot"];
+  "char": (value: string) => BaseHTMLElements["tfoot"];
   /** @deprecated This attribute is used to indicate the number of characters to offset the column data from the alignment characters specified by the char attribute. */
-  charoff: (value: string) => HTMLElements["tfoot"];
-  role: (value: string) => HTMLElements["tfoot"];
+  "charoff": (value: string) => BaseHTMLElements["tfoot"];
+  "role": (value: string) => BaseHTMLElements["tfoot"];
   /** @deprecated This attribute specifies the vertical alignment of the text within each row of cells of the table footer. Possible values for this attribute are: baseline, which will put the text as close to the bottom of the cell as it is possible, but align it on the baseline of the characters instead of the bottom of them. If characters are all of the size, this has the same effect as bottom. bottom, which will put the text as close to the bottom of the cell as it is possible; middle, which will center the text in the cell; and top, which will put the text as close to the top of the cell as it is possible. Note: Do not use this attribute as it is obsolete (and not supported) in the latest standard: instead set the CSS vertical-align property on it. */
-  valign: (value: string) => HTMLElements["tfoot"];
-} & GlobalAriaAttributes<"tfoot"> &
-  GlobalHTMLAttributes<"tfoot">;
+  "valign": (value: string) => BaseHTMLElements["tfoot"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<tfootElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<tfootElement>[key] } & { (...children: children): tfootElement; };
 
 type thElement = {
-  abbr: (value: string) => HTMLElements["th"];
+  "abbr": (value: string) => BaseHTMLElements["th"];
   /** @deprecated This enumerated attribute specifies how the cell content's horizontal alignment will be handled. Possible values are: left: The content is aligned to the left of the cell. center: The content is centered in the cell. right: The content is aligned to the right of the cell. justify (with text only): The content is stretched out inside the cell so that it covers its entire width. char (with text only): The content is aligned to a character inside the <th> element with minimal offset. This character is defined by the char and charoff attributes. The default value when this attribute is not specified is left. Note: Do not use this attribute as it is obsolete in the latest standard. To achieve the same effect as the left, center, right or justify values, apply the CSS text-align property to the element. To achieve the same effect as the char value, give the text-align property the same value you would use for the char. */
-  align: (value: string) => HTMLElements["th"];
+  "align": (value: string) => BaseHTMLElements["th"];
   /** @deprecated This attribute contains a list of space-separated strings. Each string is the id of a group of cells that this header applies to. Note: Do not use this attribute as it is obsolete in the latest standard: use the scope attribute instead. */
-  axis: (value: string) => HTMLElements["th"];
+  "axis": (value: string) => BaseHTMLElements["th"];
   /** @deprecated This attribute defines the background color of each cell in a column. It consists of a 6-digit hexadecimal code as defined in sRGB and is prefixed by '#'. This attribute may be used with one of sixteen predefined color strings: black = "#000000" green = "#008000" silver = "#C0C0C0" lime = "#00FF00" gray = "#808080" olive = "#808000" white = "#FFFFFF" yellow = "#FFFF00" maroon = "#800000" navy = "#000080" red = "#FF0000" blue = "#0000FF" purple = "#800080" teal = "#008080" fuchsia = "#FF00FF" aqua = "#00FFFF" Note: Do not use this attribute, as it is non-standard and only implemented in some versions of Microsoft Internet Explorer: The <th> element should be styled using CSS. To create a similar effect use the background-color property in CSS instead. */
-  bgcolor: (value: string) => HTMLElements["th"];
+  "bgcolor": (value: string) => BaseHTMLElements["th"];
   /** @deprecated The content in the cell element is aligned to a character. Typical values include a period (.) to align numbers or monetary values. If align is not set to char, this attribute is ignored. Note: Do not use this attribute as it is obsolete in the latest standard. To achieve the same effect, you can specify the character as the first value of the text-align property. */
-  char: (value: string) => HTMLElements["th"];
+  "char": (value: string) => BaseHTMLElements["th"];
   /** @deprecated This attribute is used to shift column data to the right of the character specified by the char attribute. Its value specifies the length of this shift. Note: Do not use this attribute as it is obsolete in the latest standard. */
-  charoff: (value: string) => HTMLElements["th"];
+  "charoff": (value: string) => BaseHTMLElements["th"];
   /** This attribute contains a non-negative integer value that indicates for how many columns the cell extends. Its default value is 1. Values higher than 1000 will be considered as incorrect and will be set to the default value (1). */
-  colspan: (value: string) => HTMLElements["th"];
+  "colspan": (value: string) => BaseHTMLElements["th"];
   /** This attribute contains a list of space-separated strings, each corresponding to the id attribute of the <th> elements that apply to this element. */
-  headers: (value: string) => HTMLElements["th"];
+  "headers": (value: string) => BaseHTMLElements["th"];
   /** @deprecated This attribute is used to define a recommended cell height. Note: Do not use this attribute as it is obsolete in the latest standard: use the CSS height property instead. */
-  height: (value: string) => HTMLElements["th"];
-  role: (value: string) => HTMLElements["th"];
+  "height": (value: string) => BaseHTMLElements["th"];
+  "role": (value: string) => BaseHTMLElements["th"];
   /** This attribute contains a non-negative integer value that indicates for how many rows the cell extends. Its default value is 1; if its value is set to 0, it extends until the end of the table section (<thead>, <tbody>, <tfoot>, even if implicitly defined), that the cell belongs to. Values higher than 65534 are clipped down to 65534. */
-  rowspan: (value: string) => HTMLElements["th"];
-  scope: (value: "row" | "col" | "rowgroup" | "colgroup") => HTMLElements["th"];
+  "rowspan": (value: string) => BaseHTMLElements["th"];
+  "scope": (value: "row" | "col" | "rowgroup" | "colgroup") => BaseHTMLElements["th"];
   /** @deprecated This attribute specifies how a text is vertically aligned inside a cell. Possible values for this attribute are: baseline: Positions the text near the bottom of the cell and aligns it with the baseline of the characters instead of the bottom. If characters don't descend below the baseline, the baseline value achieves the same effect as bottom. bottom: Positions the text near the bottom of the cell. middle: Centers the text in the cell. and top: Positions the text near the top of the cell. Note: Do not use this attribute as it is obsolete in the latest standard: use the CSS vertical-align property instead. */
-  valign: (value: string) => HTMLElements["th"];
+  "valign": (value: string) => BaseHTMLElements["th"];
   /** @deprecated This attribute is used to define a recommended cell width. Additional space can be added with the cellspacing and cellpadding properties and the width of the <col> element can also create extra width. But, if a column's width is too narrow to show a particular cell properly, it will be widened when displayed. Note: Do not use this attribute as it is obsolete in the latest standard: use the CSS width property instead. */
-  width: (value: string) => HTMLElements["th"];
-} & GlobalAriaAttributes<"th"> &
-  GlobalHTMLAttributes<"th">;
+  "width": (value: string) => BaseHTMLElements["th"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<thElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<thElement>[key] } & { (...children: children): thElement; };
 
 type theadElement = {
   /** @deprecated This enumerated attribute specifies how horizontal alignment of each cell content will be handled. Possible values are: left, aligning the content to the left of the cell center, centering the content in the cell right, aligning the content to the right of the cell justify, inserting spaces into the textual content so that the content is justified in the cell char, aligning the textual content on a special character with a minimal offset, defined by the char and charoff attributes. If this attribute is not set, the left value is assumed. Warning: Do not use this attribute as it is obsolete (not supported) in the latest standard. To achieve the same effect as the left, center, right or justify values, use the CSS text-align property on it. To achieve the same effect as the char value, in CSS3, you can use the value of the char as the value of the text-align property. */
-  align: (value: string) => HTMLElements["thead"];
+  "align": (value: string) => BaseHTMLElements["thead"];
   /** @deprecated This attribute defines the background color of each cell of the column. It is one of the 6-digit hexadecimal code as defined in sRGB, prefixed by a '#'. One of the sixteen predefined color strings may be used: black = "#000000" green = "#008000" silver = "#C0C0C0" lime = "#00FF00" gray = "#808080" olive = "#808000" white = "#FFFFFF" yellow = "#FFFF00" maroon = "#800000" navy = "#000080" red = "#FF0000" blue = "#0000FF" purple = "#800080" teal = "#008080" fuchsia = "#FF00FF" aqua = "#00FFFF" Note: Do not use this attribute, as it is non-standard and only implemented in some versions of Microsoft Internet Explorer: the <thead> element should be styled using CSS. To give a similar effect to the bgcolor attribute, use the CSS property background-color, on the relevant <td> or <th> elements. */
-  bgcolor: (value: string) => HTMLElements["thead"];
+  "bgcolor": (value: string) => BaseHTMLElements["thead"];
   /** @deprecated This attribute is used to set the character to align the cells in a column on. Typical values for this include a period (.) when attempting to align numbers or monetary values. If align is not set to char, this attribute is ignored. Note: Do not use this attribute as it is obsolete (and not supported) in the latest standard. To achieve the same effect as the char, in CSS3, you can use the character set using the char attribute as the value of the text-align property. */
-  char: (value: string) => HTMLElements["thead"];
+  "char": (value: string) => BaseHTMLElements["thead"];
   /** @deprecated This attribute is used to indicate the number of characters to offset the column data from the alignment characters specified by the char attribute. Note: Do not use this attribute as it is obsolete (and not supported) in the latest standard. */
-  charoff: (value: string) => HTMLElements["thead"];
-  role: (value: string) => HTMLElements["thead"];
+  "charoff": (value: string) => BaseHTMLElements["thead"];
+  "role": (value: string) => BaseHTMLElements["thead"];
   /** @deprecated This attribute specifies the vertical alignment of the text within each row of cells of the table header. Possible values for this attribute are: baseline, which will put the text as close to the bottom of the cell as it is possible, but align it on the baseline of the characters instead of the bottom of them. If characters are all of the size, this has the same effect as bottom. bottom, which will put the text as close to the bottom of the cell as it is possible; middle, which will center the text in the cell; top, which will put the text as close to the top of the cell as it is possible. Note: Do not use this attribute as it is obsolete (and not supported) in the latest standard: instead set the CSS vertical-align property on it. */
-  valign: (value: string) => HTMLElements["thead"];
-} & GlobalAriaAttributes<"thead"> &
-  GlobalHTMLAttributes<"thead">;
+  "valign": (value: string) => BaseHTMLElements["thead"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<theadElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<theadElement>[key] } & { (...children: children): theadElement; };
 
 type timeElement = {
-  datetime: (value: string) => HTMLElements["time"];
-  role: (value: string) => HTMLElements["time"];
-} & GlobalAriaAttributes<"time"> &
-  GlobalHTMLAttributes<"time">;
+  "datetime": (value: string) => BaseHTMLElements["time"];
+  "role": (value: string) => BaseHTMLElements["time"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<timeElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<timeElement>[key] } & { (...children: children): timeElement; };
 
 type titleElement = {
-  role: (value: string) => HTMLElements["title"];
-} & GlobalAriaAttributes<"title"> &
-  GlobalHTMLAttributes<"title">;
+  "role": (value: string) => BaseHTMLElements["title"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<titleElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<titleElement>[key] } & { (...children: children): titleElement; };
 
 type trElement = {
   /** @deprecated A DOMString which specifies how the cell's context should be aligned horizontally within the cells in the row; this is shorthand for using align on every cell in the row individually. Possible values are: left Align the content of each cell at its left edge. center Center the contents of each cell between their left and right edges. right Align the content of each cell at its right edge. justify Widen whitespaces within the text of each cell so that the text fills the full width of each cell (full justification). char Align each cell in the row on a specific character (such that each row in the column that is configured this way will horizontally align its cells on that character). This uses the char and charoff to establish the alignment character (typically "." or "," when aligning numerical data) and the number of characters that should follow the alignment character. This alignment type was never widely supported. If no value is expressly set for align, the parent node's value is inherited. Note: Instead of using the obsolete align attribute, you should instead use the CSS text-align property to establish left, center, right, or justify alignment for the row's cells. To apply character-based alignment, set the CSS text-align property to the alignment character (such as "." or ","). */
-  align: (value: string) => HTMLElements["tr"];
+  "align": (value: string) => BaseHTMLElements["tr"];
   /** @deprecated A DOMString specifying a color to apply to the backgrounds of each of the row's cells. This can be either an hexadecimal #RRGGBB or #RGB value or a color keyword. Omitting the attribute or setting it to null in JavaScript causes the row's cells to inherit the row's parent element's background color. Note: The <tr> element should be styled using CSS. To give a similar effect as the bgcolor attribute, use the CSS property background-color. */
-  bgcolor: (value: string) => HTMLElements["tr"];
+  "bgcolor": (value: string) => BaseHTMLElements["tr"];
   /** @deprecated A DOMString which sets the character to align the cells in each of the row's columns on (each row's centering that uses the same character gets aligned with others using the same character . Typical values for this include a period (".") or comma (",") when attempting to align numbers or monetary values. If align is not set to char, this attribute is ignored. Note: This attribute is not only obsolete, but was rarely implemented anyway. To achieve the same effect as the char attribute, set the CSS text-align property to the same string you would specify for the char property, such as text-align: ".". */
-  char: (value: string) => HTMLElements["tr"];
+  "char": (value: string) => BaseHTMLElements["tr"];
   /** @deprecated A DOMString indicating the number of characters on the tail end of the column's data should be displayed after the alignment character specified by the char attribute. For example, when displaying money values for currencies that use hundredths of a unit (such as the dollar, which is divided into 100 cents), you would typically specify a value of 2, so that in tandem with char being set to ".", the values in a column would be cleanly aligned on the decimal points, with the number of cents properly displayed to the right of the decimal point. Note: This attribute is obsolete, and was never widely supported anyway. */
-  charoff: (value: string) => HTMLElements["tr"];
-  role: (value: string) => HTMLElements["tr"];
+  "charoff": (value: string) => BaseHTMLElements["tr"];
+  "role": (value: string) => BaseHTMLElements["tr"];
   /** @deprecated A DOMString specifying the vertical alignment of the text within each cell in the row. Possible values for this attribute are: baseline Aligns each cell's content text as closely as possible to the bottom of the cell, handling alignment of different fonts and font sizes by aligning the characters along the baseline of the font(s) used in the row. If all of the characters in the row are the same size, the effect is the same as bottom. bottom, Draws the text in each of the row's cells as closely as possible to the bottom edge of those cells. middle Each cell's text is vertically centered. top Each cell's text is drawn as closely as possible to the top edge of the containing cell. Note: Don't use the obsolete valign attribute. Instead, add the CSS vertical-align property to the row. */
-  valign: (value: string) => HTMLElements["tr"];
-} & GlobalAriaAttributes<"tr"> &
-  GlobalHTMLAttributes<"tr">;
+  "valign": (value: string) => BaseHTMLElements["tr"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<trElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<trElement>[key] } & { (...children: children): trElement; };
 
 type trackElement = {
-  default: (value: boolean) => HTMLElements["track"];
-  kind: (
-    value: "subtitles" | "captions" | "descriptions" | "chapters" | "metadata"
-  ) => HTMLElements["track"];
-  label: (value: string) => HTMLElements["track"];
-  role: (value: string) => HTMLElements["track"];
-  src: (value: string) => HTMLElements["track"];
-  srclang: (value: string) => HTMLElements["track"];
-} & GlobalAriaAttributes<"track"> &
-  GlobalHTMLAttributes<"track">;
+  "default": (value: boolean) => BaseHTMLElements["track"];
+  "kind": (value: "subtitles" | "captions" | "descriptions" | "chapters" | "metadata") => BaseHTMLElements["track"];
+  "label": (value: string) => BaseHTMLElements["track"];
+  "role": (value: string) => BaseHTMLElements["track"];
+  "src": (value: string) => BaseHTMLElements["track"];
+  "srclang": (value: string) => BaseHTMLElements["track"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<trackElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<trackElement>[key] } & { (...children: children): trackElement; };
 
-type ttElement = {} & GlobalAriaAttributes<"tt"> & GlobalHTMLAttributes<"tt">;
+type ttElement = {
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<ttElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<ttElement>[key] } & { (...children: children): ttElement; };
 
 type uElement = {
-  role: (value: string) => HTMLElements["u"];
-} & GlobalAriaAttributes<"u"> &
-  GlobalHTMLAttributes<"u">;
+  "role": (value: string) => BaseHTMLElements["u"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<uElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<uElement>[key] } & { (...children: children): uElement; };
 
 type ulElement = {
   /** @deprecated This Boolean attribute hints that the list should be rendered in a compact style. The interpretation of this attribute depends on the user agent, and it doesn't work in all browsers. Warning: Do not use this attribute, as it has been deprecated: use CSS instead. To give a similar effect as the compact attribute, the CSS property line-height can be used with a value of 80%. */
-  compact: (value: string) => HTMLElements["ul"];
-  role: (value: string) => HTMLElements["ul"];
+  "compact": (value: string) => BaseHTMLElements["ul"];
+  "role": (value: string) => BaseHTMLElements["ul"];
   /** @deprecated This attribute sets the bullet style for the list. The values defined under HTML3.2 and the transitional version of HTML 4.0/4.01 are: circle disc square A fourth bullet type has been defined in the WebTV interface, but not all browsers support it: triangle. If not present and if no CSS list-style-type property applies to the element, the user agent selects a bullet type depending on the nesting level of the list. Warning: Do not use this attribute, as it has been deprecated; use the CSS list-style-type property instead. */
-  type: (value: string) => HTMLElements["ul"];
-} & GlobalAriaAttributes<"ul"> &
-  GlobalHTMLAttributes<"ul">;
+  "type": (value: string) => BaseHTMLElements["ul"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<ulElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<ulElement>[key] } & { (...children: children): ulElement; };
 
 type varElement = {
-  role: (value: string) => HTMLElements["var"];
-} & GlobalAriaAttributes<"var"> &
-  GlobalHTMLAttributes<"var">;
+  "role": (value: string) => BaseHTMLElements["var"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<varElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<varElement>[key] } & { (...children: children): varElement; };
 
 type videoElement = {
   /** A Boolean attribute which if true indicates that the element should automatically toggle picture-in-picture mode when the user switches back and forth between this document and another document or application. */
-  autopictureinpicture: (value: string) => HTMLElements["video"];
+  "autopictureinpicture": (value: string) => BaseHTMLElements["video"];
   /** A Boolean attribute; if specified, the video automatically begins to play back as soon as it can do so without stopping to finish loading the data. Note: Sites that automatically play audio (or videos with an audio track) can be an unpleasant experience for users, so should be avoided when possible. If you must offer autoplay functionality, you should make it opt-in (requiring a user to specifically enable it). However, this can be useful when creating media elements whose source will be set at a later time, under user control. See our autoplay guide for additional information about how to properly use autoplay. To disable video autoplay, autoplay="false" will not work; the video will autoplay if the attribute is there in the <video> tag at all. To remove autoplay, the attribute needs to be removed altogether. In some browsers (e.g. Chrome 70.0) autoplay doesn't work if no muted attribute is present. */
-  autoplay: (value: boolean) => HTMLElements["video"];
+  "autoplay": (value: boolean) => BaseHTMLElements["video"];
   /** If this attribute is present, the browser will offer controls to allow the user to control video playback, including volume, seeking, and pause/resume playback. */
-  controls: (value: boolean) => HTMLElements["video"];
-  controlslist: (value: string) => HTMLElements["video"];
+  "controls": (value: boolean) => BaseHTMLElements["video"];
+  "controlslist": (value: string) => BaseHTMLElements["video"];
   /** This enumerated attribute indicates whether to use CORS to fetch the related video. CORS-enabled resources can be reused in the <canvas> element without being tainted. The allowed values are: anonymous Sends a cross-origin request without a credential. In other words, it sends the Origin: HTTP header without a cookie, X.509 certificate, or performing HTTP Basic authentication. If the server does not give credentials to the origin site (by not setting the Access-Control-Allow-Origin: HTTP header), the image will be tainted, and its usage restricted. use-credentials Sends a cross-origin request with a credential. In other words, it sends the Origin: HTTP header with a cookie, a certificate, or performing HTTP Basic authentication. If the server does not give credentials to the origin site (through Access-Control-Allow-Credentials: HTTP header), the image will be tainted and its usage restricted. When not present, the resource is fetched without a CORS request (i.e. without sending the Origin: HTTP header), preventing its non-tainted used in <canvas> elements. If invalid, it is handled as if the enumerated keyword anonymous was used. See CORS settings attributes for additional information. */
-  crossorigin: (
-    value: "" | "anonymous" | "use-credentials"
-  ) => HTMLElements["video"];
+  "crossorigin": (value: "" | "anonymous" | "use-credentials") => BaseHTMLElements["video"];
   /** Prevents the browser from suggesting a Picture-in-Picture context menu or to request Picture-in-Picture automatically in some cases. */
-  disablepictureinpicture: (value: string) => HTMLElements["video"];
+  "disablepictureinpicture": (value: string) => BaseHTMLElements["video"];
   /** A Boolean attribute used to disable the capability of remote playback in devices that are attached using wired (HDMI, DVI, etc.) and wireless technologies (Miracast, Chromecast, DLNA, AirPlay, etc). In Safari, you can use x-webkit-airplay="deny" as a fallback. */
-  disableremoteplayback: (value: string) => HTMLElements["video"];
+  "disableremoteplayback": (value: string) => BaseHTMLElements["video"];
   /** The height of the video's display area, in CSS pixels (absolute values only; no percentages.) */
-  height: (value: number) => HTMLElements["video"];
+  "height": (value: number) => BaseHTMLElements["video"];
   /** A Boolean attribute; if specified, the browser will automatically seek back to the start upon reaching the end of the video. */
-  loop: (value: boolean) => HTMLElements["video"];
+  "loop": (value: boolean) => BaseHTMLElements["video"];
   /** A Boolean attribute that indicates the default setting of the audio contained in the video. If set, the audio will be initially silenced. Its default value is false, meaning that the audio will be played when the video is played. */
-  muted: (value: boolean) => HTMLElements["video"];
-  playsinline: (value: boolean) => HTMLElements["video"];
-  poster: (value: string) => HTMLElements["video"];
+  "muted": (value: boolean) => BaseHTMLElements["video"];
+  "playsinline": (value: boolean) => BaseHTMLElements["video"];
+  "poster": (value: string) => BaseHTMLElements["video"];
   /** This enumerated attribute is intended to provide a hint to the browser about what the author thinks will lead to the best user experience with regards to what content is loaded before the video is played. It may have one of the following values: none: Indicates that the video should not be preloaded. metadata: Indicates that only video metadata (e.g. length) is fetched. auto: Indicates that the whole video file can be downloaded, even if the user is not expected to use it. empty string: Synonym of the auto value. The default value is different for each browser. The spec advises it to be set to metadata. Note: The autoplay attribute has precedence over preload. If autoplay is specified, the browser would obviously need to start downloading the video for playback. The specification does not force the browser to follow the value of this attribute; it is a mere hint. */
-  preload: (value: "none" | "metadata" | "auto") => HTMLElements["video"];
-  role: (value: string) => HTMLElements["video"];
+  "preload": (value: "none" | "metadata" | "auto") => BaseHTMLElements["video"];
+  "role": (value: string) => BaseHTMLElements["video"];
   /** The URL of the video to embed. This is optional; you may instead use the <source> element within the video block to specify the video to embed. */
-  src: (value: string) => HTMLElements["video"];
+  "src": (value: string) => BaseHTMLElements["video"];
   /** The width of the video's display area, in CSS pixels (absolute values only; no percentages). */
-  width: (value: number) => HTMLElements["video"];
-} & GlobalAriaAttributes<"video"> &
-  GlobalHTMLAttributes<"video">;
+  "width": (value: number) => BaseHTMLElements["video"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<videoElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<videoElement>[key] } & { (...children: children): videoElement; };
 
 type wbrElement = {
-  role: (value: string) => HTMLElements["wbr"];
-} & GlobalAriaAttributes<"wbr"> &
-  GlobalHTMLAttributes<"wbr">;
+  "role": (value: string) => BaseHTMLElements["wbr"];
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<wbrElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<wbrElement>[key] } & { (...children: children): wbrElement; };
 
-type xmpElement = {} & GlobalAriaAttributes<"xmp"> &
-  GlobalHTMLAttributes<"xmp">;
+type xmpElement = {
+} & { [key in keyof GlobalHTMLAttributes<any>]: GlobalHTMLAttributes<xmpElement>[key] } & { [key in keyof GlobalAriaAttributes<any>]: GlobalAriaAttributes<xmpElement>[key] } & { (...children: children): xmpElement; };

--- a/packages/hdot/src/types/html.ts
+++ b/packages/hdot/src/types/html.ts
@@ -1,1700 +1,2002 @@
 // WARNING: This file was auto-generated and any changes will be overwritten.
 export type HTMLElements = {
   /** The <a> HTML element (or anchor element), with its href attribute, creates a hyperlink to web pages, files, email addresses, locations in the same page, or anything else a URL can address. */
-  "a": aElement;
+  a: aElement;
   /** The <abbr> HTML element represents an abbreviation or acronym; the optional title attribute can provide an expansion or description for the abbreviation. If present, title must contain this full description and nothing else. */
-  "abbr": abbrElement;
+  abbr: abbrElement;
   /** @deprecated The <acronym> HTML element allows authors to clearly indicate a sequence of characters that compose an acronym or abbreviation for a word. */
-  "acronym": acronymElement;
+  acronym: acronymElement;
   /** The <address> HTML element indicates that the enclosed HTML provides contact information for a person or people, or for an organization. */
-  "address": addressElement;
+  address: addressElement;
   /** @deprecated The obsolete HTML Applet Element (<applet>) embeds a Java applet into the document; this element has been deprecated in favor of <object>. */
-  "applet": appletElement;
+  applet: appletElement;
   /** The <area> HTML element defines an area inside an image map that has predefined clickable areas. An image map allows geometric areas on an image to be associated with hypertext link. */
-  "area": areaElement;
+  area: areaElement;
   /** The <article> HTML element represents a self-contained composition in a document, page, application, or site, which is intended to be independently distributable or reusable (e.g., in syndication). Examples include: a forum post, a magazine or newspaper article, or a blog entry, a product card, a user-submitted comment, an interactive widget or gadget, or any other independent item of content. */
-  "article": articleElement;
+  article: articleElement;
   /** The <aside> HTML element represents a portion of a document whose content is only indirectly related to the document's main content. Asides are frequently presented as sidebars or call-out boxes. */
-  "aside": asideElement;
+  aside: asideElement;
   /** The <audio> HTML element is used to embed sound content in documents. It may contain one or more audio sources, represented using the src attribute or the <source> element: the browser will choose the most suitable one. It can also be the destination for streamed media, using a MediaStream. */
-  "audio": audioElement;
+  audio: audioElement;
   /** The <b> HTML element is used to draw the reader's attention to the element's contents, which are not otherwise granted special importance. This was formerly known as the Boldface element, and most browsers still draw the text in boldface. However, you should not use <b> for styling text; instead, you should use the CSS font-weight property to create boldface text, or the <strong> element to indicate that text is of special importance. */
-  "b": bElement;
+  b: bElement;
   /** The <base> HTML element specifies the base URL to use for all relative URLs in a document. There can be only one <base> element in a document. */
-  "base": baseElement;
+  base: baseElement;
   /** @deprecated The <basefont> HTML element is deprecated. It sets a default font face, size, and color for the other elements which are descended from its parent element. With this set, the font's size can then be varied relative to the base size using the <font> element. */
-  "basefont": basefontElement;
+  basefont: basefontElement;
   /** The <bdi> HTML element tells the browser's bidirectional algorithm to treat the text it contains in isolation from its surrounding text. It's particularly useful when a website dynamically inserts some text and doesn't know the directionality of the text being inserted. */
-  "bdi": bdiElement;
+  bdi: bdiElement;
   /** The <bdo> HTML element overrides the current directionality of text, so that the text within is rendered in a different direction. */
-  "bdo": bdoElement;
+  bdo: bdoElement;
   /** @deprecated The <bgsound> HTML element is deprecated. It sets up a sound file to play in the background while the page is used; use <audio> instead. */
-  "bgsound": bgsoundElement;
+  bgsound: bgsoundElement;
   /** @deprecated The <big> HTML deprecated element renders the enclosed text at a font size one level larger than the surrounding text (medium becomes large, for example). The size is capped at the browser's maximum permitted font size. */
-  "big": bigElement;
+  big: bigElement;
   /** @deprecated The <blink> HTML element is a non-standard element which causes the enclosed text to flash slowly. */
-  "blink": blinkElement;
+  blink: blinkElement;
   /** The <blockquote> HTML element indicates that the enclosed text is an extended quotation. Usually, this is rendered visually by indentation (see Notes for how to change it). A URL for the source of the quotation may be given using the cite attribute, while a text representation of the source can be given using the <cite> element. */
-  "blockquote": blockquoteElement;
+  blockquote: blockquoteElement;
   /** The <body> HTML element represents the content of an HTML document. There can be only one <body> element in a document. */
-  "body": bodyElement;
+  body: bodyElement;
   /** The <br> HTML element produces a line break in text (carriage-return). It is useful for writing a poem or an address, where the division of lines is significant. */
-  "br": brElement;
+  br: brElement;
   /** The <button> HTML element represents a clickable button, used to submit forms or anywhere in a document for accessible, standard button functionality. */
-  "button": buttonElement;
+  button: buttonElement;
   /** Use the HTML <canvas> element with either the canvas scripting API or the WebGL API to draw graphics and animations. */
-  "canvas": canvasElement;
+  canvas: canvasElement;
   /** The <caption> HTML element specifies the caption (or title) of a table. */
-  "caption": captionElement;
+  caption: captionElement;
   /** @deprecated The <center> HTML element is a block-level element that displays its block-level or inline contents centered horizontally within its containing element. The container is usually, but isn't required to be, <body>. */
-  "center": centerElement;
+  center: centerElement;
   /** The <cite> HTML element is used to describe a reference to a cited creative work, and must include the title of that work. The reference may be in an abbreviated form according to context-appropriate conventions related to citation metadata. */
-  "cite": citeElement;
+  cite: citeElement;
   /** The <code> HTML element displays its contents styled in a fashion intended to indicate that the text is a short fragment of computer code. By default, the content text is displayed using the user agent's default monospace font. */
-  "code": codeElement;
+  code: codeElement;
   /** The <col> HTML element defines a column within a table and is used for defining common semantics on all common cells. It is generally found within a <colgroup> element. */
-  "col": colElement;
+  col: colElement;
   /** The <colgroup> HTML element defines a group of columns within a table. */
-  "colgroup": colgroupElement;
+  colgroup: colgroupElement;
   /** @deprecated The <content> HTML element—an obsolete part of the Web Components suite of technologies—was used inside of Shadow DOM as an insertion point, and wasn't meant to be used in ordinary HTML. It has now been replaced by the <slot> element, which creates a point in the DOM at which a shadow DOM can be inserted. */
-  "content": contentElement;
+  content: contentElement;
   /** The <data> HTML element links a given piece of content with a machine-readable translation. If the content is time- or date-related, the <time> element must be used. */
-  "data": dataElement;
+  data: dataElement;
   /** The <datalist> HTML element contains a set of <option> elements that represent the permissible or recommended options available to choose from within other controls. */
-  "datalist": datalistElement;
+  datalist: datalistElement;
   /** The <dd> HTML element provides the description, definition, or value for the preceding term (<dt>) in a description list (<dl>). */
-  "dd": ddElement;
+  dd: ddElement;
   /** The <del> HTML element represents a range of text that has been deleted from a document. This can be used when rendering "track changes" or source code diff information, for example. The <ins> element can be used for the opposite purpose: to indicate text that has been added to the document. */
-  "del": delElement;
+  del: delElement;
   /** The <details> HTML element creates a disclosure widget in which information is visible only when the widget is toggled into an "open" state. A summary or label must be provided using the <summary> element. */
-  "details": detailsElement;
+  details: detailsElement;
   /** The <dfn> HTML element is used to indicate the term being defined within the context of a definition phrase or sentence. The <p> element, the <dt>/<dd> pairing, or the <section> element which is the nearest ancestor of the <dfn> is considered to be the definition of the term. */
-  "dfn": dfnElement;
+  dfn: dfnElement;
   /** The <dialog> HTML element represents a dialog box or other interactive component, such as a dismissible alert, inspector, or subwindow. */
-  "dialog": dialogElement;
+  dialog: dialogElement;
   /** @deprecated The <dir> HTML element is used as a container for a directory of files and/or folders, potentially with styles and icons applied by the user agent. Do not use this obsolete element; instead, you should use the <ul> element for lists, including lists of files. */
-  "dir": dirElement;
+  dir: dirElement;
   /** The <div> HTML element is the generic container for flow content. It has no effect on the content or layout until styled in some way using CSS (e.g. styling is directly applied to it, or some kind of layout model like Flexbox is applied to its parent element). */
-  "div": divElement;
+  div: divElement;
   /** The <dl> HTML element represents a description list. The element encloses a list of groups of terms (specified using the <dt> element) and descriptions (provided by <dd> elements). Common uses for this element are to implement a glossary or to display metadata (a list of key-value pairs). */
-  "dl": dlElement;
+  dl: dlElement;
   /** The <dt> HTML element specifies a term in a description or definition list, and as such must be used inside a <dl> element. It is usually followed by a <dd> element; however, multiple <dt> elements in a row indicate several terms that are all defined by the immediate next <dd> element. */
-  "dt": dtElement;
+  dt: dtElement;
   /** The <em> HTML element marks text that has stress emphasis. The <em> element can be nested, with each level of nesting indicating a greater degree of emphasis. */
-  "em": emElement;
+  em: emElement;
   /** The <embed> HTML element embeds external content at the specified point in the document. This content is provided by an external application or other source of interactive content such as a browser plug-in. */
-  "embed": embedElement;
+  embed: embedElement;
   /** The <fieldset> HTML element is used to group several controls as well as labels (<label>) within a web form. */
-  "fieldset": fieldsetElement;
+  fieldset: fieldsetElement;
   /** The <figcaption> HTML element represents a caption or legend describing the rest of the contents of its parent <figure> element. */
-  "figcaption": figcaptionElement;
+  figcaption: figcaptionElement;
   /** The <figure> HTML element represents self-contained content, potentially with an optional caption, which is specified using the <figcaption> element. The figure, its caption, and its contents are referenced as a single unit. */
-  "figure": figureElement;
+  figure: figureElement;
   /** @deprecated The <font> HTML element defines the font size, color and face for its content. */
-  "font": fontElement;
+  font: fontElement;
   /** The <footer> HTML element represents a footer for its nearest sectioning content or sectioning root element. A <footer> typically contains information about the author of the section, copyright data or links to related documents. */
-  "footer": footerElement;
+  footer: footerElement;
   /** The <form> HTML element represents a document section containing interactive controls for submitting information. */
-  "form": formElement;
+  form: formElement;
   /** @deprecated The <frame> HTML element defines a particular area in which another HTML document can be displayed. A frame should be used within a <frameset>. */
-  "frame": frameElement;
+  frame: frameElement;
   /** @deprecated The <frameset> HTML element is used to contain <frame> elements. */
-  "frameset": framesetElement;
+  frameset: framesetElement;
   /** The <h1> to <h6> HTML elements represent six levels of section headings. <h1> is the highest section level and <h6> is the lowest. */
-  "h1": h1Element;
+  h1: h1Element;
   /** The <h1> to <h6> HTML elements represent six levels of section headings. <h1> is the highest section level and <h6> is the lowest. */
-  "h2": h2Element;
+  h2: h2Element;
   /** The <h1> to <h6> HTML elements represent six levels of section headings. <h1> is the highest section level and <h6> is the lowest. */
-  "h3": h3Element;
+  h3: h3Element;
   /** The <h1> to <h6> HTML elements represent six levels of section headings. <h1> is the highest section level and <h6> is the lowest. */
-  "h4": h4Element;
+  h4: h4Element;
   /** The <h1> to <h6> HTML elements represent six levels of section headings. <h1> is the highest section level and <h6> is the lowest. */
-  "h5": h5Element;
+  h5: h5Element;
   /** The <head> HTML element contains machine-readable information (metadata) about the document, like its title, scripts, and style sheets. */
-  "head": headElement;
+  head: headElement;
   /** The <header> HTML element represents introductory content, typically a group of introductory or navigational aids. It may contain some heading elements but also a logo, a search form, an author name, and other elements. */
-  "header": headerElement;
+  header: headerElement;
   /** The <hgroup> HTML element represents a multi-level heading for a section of a document. It groups a set of <h1>–<h6> elements. */
-  "hgroup": hgroupElement;
+  hgroup: hgroupElement;
   /** The <hr> HTML element represents a thematic break between paragraph-level elements: for example, a change of scene in a story, or a shift of topic within a section. */
-  "hr": hrElement;
+  hr: hrElement;
   /** The <html> HTML element represents the root (top-level element) of an HTML document, so it is also referred to as the root element. All other elements must be descendants of this element. */
-  "html": htmlElement;
+  html: htmlElement;
   /** The <i> HTML element represents a range of text that is set off from the normal text for some reason, such as idiomatic text, technical terms, taxonomical designations, among others. Historically, these have been presented using italicized type, which is the original source of the <i> naming of this element. */
-  "i": iElement;
+  i: iElement;
   /** The <iframe> HTML element represents a nested browsing context, embedding another HTML page into the current one. */
-  "iframe": iframeElement;
+  iframe: iframeElement;
   /** @deprecated The <image> HTML element is an ancient and poorly supported precursor to the <img> element. It should not be used. */
-  "image": imageElement;
+  image: imageElement;
   /** The <img> HTML element embeds an image into the document. */
-  "img": imgElement;
+  img: imgElement;
   /** The <input> HTML element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent. The <input> element is one of the most powerful and complex in all of HTML due to the sheer number of combinations of input types and attributes. */
-  "input": inputElement;
+  input: inputElement;
   /** The <ins> HTML element represents a range of text that has been added to a document. You can use the <del> element to similarly represent a range of text that has been deleted from the document. */
-  "ins": insElement;
+  ins: insElement;
   /** Element is entirely obsolete, and must not be used by authors. */
-  "isindex": isindexElement;
+  isindex: isindexElement;
   /** The <kbd> HTML element represents a span of inline text denoting textual user input from a keyboard, voice input, or any other text entry device. By convention, the user agent defaults to rendering the contents of a <kbd> element using its default monospace font, although this is not mandated by the HTML standard. */
-  "kbd": kbdElement;
+  kbd: kbdElement;
   /** @deprecated The <keygen> HTML element exists to facilitate generation of key material, and submission of the public key as part of an HTML form. This mechanism is designed for use with Web-based certificate management systems. It is expected that the <keygen> element will be used in an HTML form along with other information needed to construct a certificate request, and that the result of the process will be a signed certificate. */
-  "keygen": keygenElement;
+  keygen: keygenElement;
   /** The <label> HTML element represents a caption for an item in a user interface. */
-  "label": labelElement;
+  label: labelElement;
   /** The <legend> HTML element represents a caption for the content of its parent <fieldset>. */
-  "legend": legendElement;
+  legend: legendElement;
   /** The <li> HTML element is used to represent an item in a list. It must be contained in a parent element: an ordered list (<ol>), an unordered list (<ul>), or a menu (<menu>). In menus and unordered lists, list items are usually displayed using bullet points. In ordered lists, they are usually displayed with an ascending counter on the left, such as a number or letter. */
-  "li": liElement;
+  li: liElement;
   /** The <link> HTML element specifies relationships between the current document and an external resource. This element is most commonly used to link to stylesheets, but is also used to establish site icons (both "favicon" style icons and icons for the home screen and apps on mobile devices) among other things. */
-  "link": linkElement;
+  link: linkElement;
   /** Element is entirely obsolete, and must not be used by authors. */
-  "listing": listingElement;
+  listing: listingElement;
   /** The <main> HTML element represents the dominant content of the <body> of a document. The main content area consists of content that is directly related to or expands upon the central topic of a document, or the central functionality of an application. */
-  "main": mainElement;
+  main: mainElement;
   /** The <map> HTML element is used with <area> elements to define an image map (a clickable link area). */
-  "map": mapElement;
+  map: mapElement;
   /** The <mark> HTML element represents text which is marked or highlighted for reference or notation purposes, due to the marked passage's relevance or importance in the enclosing context. */
-  "mark": markElement;
+  mark: markElement;
   /** @deprecated The <marquee> HTML element is used to insert a scrolling area of text. You can control what happens when the text reaches the edges of its content area using its attributes. */
-  "marquee": marqueeElement;
+  marquee: marqueeElement;
   /** The <menu> HTML element is a semantic alternative to <ul>. It represents an unordered list of items (represented by <li> elements), each of these represent a link or other command that the user can activate. */
-  "menu": menuElement;
+  menu: menuElement;
   /** @deprecated The <menuitem> HTML element represents a command that a user is able to invoke through a popup menu. This includes context menus, as well as menus that might be attached to a menu button. */
-  "menuitem": menuitemElement;
+  menuitem: menuitemElement;
   /** The <meta> HTML element represents metadata that cannot be represented by other HTML meta-related elements, like <base>, <link>, <script>, <style> or <title>. */
-  "meta": metaElement;
+  meta: metaElement;
   /** The <meter> HTML element represents either a scalar value within a known range or a fractional value. */
-  "meter": meterElement;
+  meter: meterElement;
   /** Element is entirely obsolete, and must not be used by authors. */
-  "multicol": multicolElement;
+  multicol: multicolElement;
   /** The <nav> HTML element represents a section of a page whose purpose is to provide navigation links, either within the current document or to other documents. Common examples of navigation sections are menus, tables of contents, and indexes. */
-  "nav": navElement;
+  nav: navElement;
   /** Element is entirely obsolete, and must not be used by authors. */
-  "nextid": nextidElement;
+  nextid: nextidElement;
   /** @deprecated The <nobr> HTML element prevents the text it contains from automatically wrapping across multiple lines, potentially resulting in the user having to scroll horizontally to see the entire width of the text. */
-  "nobr": nobrElement;
+  nobr: nobrElement;
   /** @deprecated The <noembed> HTML element is an obsolete, non-standard way to provide alternative, or "fallback", content for browsers that do not support the <embed> element or do not support the type of embedded content an author wishes to use. This element was deprecated in HTML 4.01 and above in favor of placing fallback content between the opening and closing tags of an <object> element. */
-  "noembed": noembedElement;
+  noembed: noembedElement;
   /** @deprecated The <noframes> HTML element provides content to be presented in browsers that don't support (or have disabled support for) the <frame> element. Although most commonly-used browsers support frames, there are exceptions, including certain special-use browsers including some mobile browsers, as well as text-mode browsers. */
-  "noframes": noframesElement;
+  noframes: noframesElement;
   /** The <noscript> HTML element defines a section of HTML to be inserted if a script type on the page is unsupported or if scripting is currently turned off in the browser. */
-  "noscript": noscriptElement;
+  noscript: noscriptElement;
   /** The <object> HTML element represents an external resource, which can be treated as an image, a nested browsing context, or a resource to be handled by a plugin. */
-  "object": objectElement;
+  object: objectElement;
   /** The <ol> HTML element represents an ordered list of items — typically rendered as a numbered list. */
-  "ol": olElement;
+  ol: olElement;
   /** The <optgroup> HTML element creates a grouping of options within a <select> element. */
-  "optgroup": optgroupElement;
+  optgroup: optgroupElement;
   /** The <option> HTML element is used to define an item contained in a <select>, an <optgroup>, or a <datalist> element. As such, <option> can represent menu items in popups and other lists of items in an HTML document. */
-  "option": optionElement;
+  option: optionElement;
   /** The <output> HTML element is a container element into which a site or app can inject the results of a calculation or the outcome of a user action. */
-  "output": outputElement;
+  output: outputElement;
   /** The <p> HTML element represents a paragraph. Paragraphs are usually represented in visual media as blocks of text separated from adjacent blocks by blank lines and/or first-line indentation, but HTML paragraphs can be any structural grouping of related content, such as images or form fields. */
-  "p": pElement;
+  p: pElement;
   /** The <param> HTML element defines parameters for an <object> element. */
-  "param": paramElement;
+  param: paramElement;
   /** The <picture> HTML element contains zero or more <source> elements and one <img> element to offer alternative versions of an image for different display/device scenarios. */
-  "picture": pictureElement;
+  picture: pictureElement;
   /** @deprecated The <plaintext> HTML element renders everything following the start tag as raw text, ignoring any following HTML. There is no closing tag, since everything after it is considered raw text. */
-  "plaintext": plaintextElement;
+  plaintext: plaintextElement;
   /** The <portal> HTML element enables the embedding of another HTML page into the current one for the purposes of allowing smoother navigation into new pages. */
-  "portal": portalElement;
+  portal: portalElement;
   /** The <pre> HTML element represents preformatted text which is to be presented exactly as written in the HTML file. The text is typically rendered using a non-proportional, or "monospaced, font. Whitespace inside this element is displayed as written. */
-  "pre": preElement;
+  pre: preElement;
   /** The <progress> HTML element displays an indicator showing the completion progress of a task, typically displayed as a progress bar. */
-  "progress": progressElement;
+  progress: progressElement;
   /** The <q> HTML element indicates that the enclosed text is a short inline quotation. Most modern browsers implement this by surrounding the text in quotation marks. This element is intended for short quotations that don't require paragraph breaks; for long quotations use the <blockquote> element. */
-  "q": qElement;
+  q: qElement;
   /** @deprecated The <rb> HTML element is used to delimit the base text component of a <ruby> annotation, i.e. the text that is being annotated. One <rb> element should wrap each separate atomic segment of the base text. */
-  "rb": rbElement;
+  rb: rbElement;
   /** The <rp> HTML element is used to provide fall-back parentheses for browsers that do not support display of ruby annotations using the <ruby> element. One <rp> element should enclose each of the opening and closing parentheses that wrap the <rt> element that contains the annotation's text. */
-  "rp": rpElement;
+  rp: rpElement;
   /** The <rt> HTML element specifies the ruby text component of a ruby annotation, which is used to provide pronunciation, translation, or transliteration information for East Asian typography. The <rt> element must always be contained within a <ruby> element. */
-  "rt": rtElement;
+  rt: rtElement;
   /** @deprecated The <rtc> HTML element embraces semantic annotations of characters presented in a ruby of <rb> elements used inside of <ruby> element. <rb> elements can have both pronunciation (<rt>) and semantic (<rtc>) annotations. */
-  "rtc": rtcElement;
+  rtc: rtcElement;
   /** The <ruby> HTML element represents small annotations that are rendered above, below, or next to base text, usually used for showing the pronunciation of East Asian characters. It can also be used for annotating other kinds of text, but this usage is less common. */
-  "ruby": rubyElement;
+  ruby: rubyElement;
   /** The <s> HTML element renders text with a strikethrough, or a line through it. Use the <s> element to represent things that are no longer relevant or no longer accurate. However, <s> is not appropriate when indicating document edits; for that, use the <del> and <ins> elements, as appropriate. */
-  "s": sElement;
+  s: sElement;
   /** The <samp> HTML element is used to enclose inline text which represents sample (or quoted) output from a computer program. Its contents are typically rendered using the browser's default monospaced font (such as Courier or Lucida Console). */
-  "samp": sampElement;
+  samp: sampElement;
   /** The <script> HTML element is used to embed executable code or data; this is typically used to embed or refer to JavaScript code. The <script> element can also be used with other languages, such as WebGL's GLSL shader programming language and JSON. */
-  "script": scriptElement;
+  script: scriptElement;
   /** The <section> HTML element represents a generic standalone section of a document, which doesn't have a more specific semantic element to represent it. Sections should always have a heading, with very few exceptions. */
-  "section": sectionElement;
+  section: sectionElement;
   /** The <select> HTML element represents a control that provides a menu of options: */
-  "select": selectElement;
+  select: selectElement;
   /** @deprecated The <shadow> HTML element—an obsolete part of the Web Components technology suite—was intended to be used as a shadow DOM insertion point. You might have used it if you have created multiple shadow roots under a shadow host. It is not useful in ordinary HTML. */
-  "shadow": shadowElement;
+  shadow: shadowElement;
   /** The <slot> HTML element—part of the Web Components technology suite—is a placeholder inside a web component that you can fill with your own markup, which lets you create separate DOM trees and present them together. */
-  "slot": slotElement;
+  slot: slotElement;
   /** The <small> HTML element represents side-comments and small print, like copyright and legal text, independent of its styled presentation. By default, it renders text within it one font-size smaller, such as from small to x-small. */
-  "small": smallElement;
+  small: smallElement;
   /** The <source> HTML element specifies multiple media resources for the <picture>, the <audio> element, or the <video> element. It is an empty element, meaning that it has no content and does not have a closing tag. It is commonly used to offer the same media content in multiple file formats in order to provide compatibility with a broad range of browsers given their differing support for image file formats and media file formats. */
-  "source": sourceElement;
+  source: sourceElement;
   /** @deprecated The <spacer> HTML element is an obsolete HTML element which allowed insertion of empty spaces on pages. It was devised by Netscape to accomplish the same effect as a single-pixel layout image, which was something web designers used to use to add white spaces to web pages without actually using an image. However, <spacer> no longer supported by any major browser and the same effects can now be achieved using simple CSS. */
-  "spacer": spacerElement;
+  spacer: spacerElement;
   /** The <span> HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. <span> is very much like a <div> element, but <div> is a block-level element whereas a <span> is an inline element. */
-  "span": spanElement;
+  span: spanElement;
   /** @deprecated The <strike> HTML element places a strikethrough (horizontal line) over text. */
-  "strike": strikeElement;
+  strike: strikeElement;
   /** The <strong> HTML element indicates that its contents have strong importance, seriousness, or urgency. Browsers typically render the contents in bold type. */
-  "strong": strongElement;
+  strong: strongElement;
   /** The <style> HTML element contains style information for a document, or part of a document. It contains CSS, which is applied to the contents of the document containing the <style> element. */
-  "style": styleElement;
+  style: styleElement;
   /** The <sub> HTML element specifies inline text which should be displayed as subscript for solely typographical reasons. Subscripts are typically rendered with a lowered baseline using smaller text. */
-  "sub": subElement;
+  sub: subElement;
   /** The <summary> HTML element specifies a summary, caption, or legend for a <details> element's disclosure box. Clicking the <summary> element toggles the state of the parent <details> element open and closed. */
-  "summary": summaryElement;
+  summary: summaryElement;
   /** The <sup> HTML element specifies inline text which is to be displayed as superscript for solely typographical reasons. Superscripts are usually rendered with a raised baseline using smaller text. */
-  "sup": supElement;
+  sup: supElement;
   /** The <table> HTML element represents tabular data — that is, information presented in a two-dimensional table comprised of rows and columns of cells containing data. */
-  "table": tableElement;
+  table: tableElement;
   /** The <tbody> HTML element encapsulates a set of table rows (<tr> elements), indicating that they comprise the body of the table (<table>). */
-  "tbody": tbodyElement;
+  tbody: tbodyElement;
   /** The <td> HTML element defines a cell of a table that contains data. It participates in the table model. */
-  "td": tdElement;
+  td: tdElement;
   /** The <template> HTML element is a mechanism for holding HTML that is not to be rendered immediately when a page is loaded but may be instantiated subsequently during runtime using JavaScript. */
-  "template": templateElement;
+  template: templateElement;
   /** The <textarea> HTML element represents a multi-line plain-text editing control, useful when you want to allow users to enter a sizeable amount of free-form text, for example a comment on a review or feedback form. */
-  "textarea": textareaElement;
+  textarea: textareaElement;
   /** The <tfoot> HTML element defines a set of rows summarizing the columns of the table. */
-  "tfoot": tfootElement;
+  tfoot: tfootElement;
   /** The <th> HTML element defines a cell as header of a group of table cells. The exact nature of this group is defined by the scope and headers attributes. */
-  "th": thElement;
+  th: thElement;
   /** The <thead> HTML element defines a set of rows defining the head of the columns of the table. */
-  "thead": theadElement;
+  thead: theadElement;
   /** The <time> HTML element represents a specific period in time. It may include the datetime attribute to translate dates into machine-readable format, allowing for better search engine results or custom features such as reminders. */
-  "time": timeElement;
+  time: timeElement;
   /** The <title> HTML element defines the document's title that is shown in a browser's title bar or a page's tab. It only contains text; tags within the element are ignored. */
-  "title": titleElement;
+  title: titleElement;
   /** The <tr> HTML element defines a row of cells in a table. The row's cells can then be established using a mix of <td> (data cell) and <th> (header cell) elements. */
-  "tr": trElement;
+  tr: trElement;
   /** The <track> HTML element is used as a child of the media elements, <audio> and <video>. It lets you specify timed text tracks (or time-based data), for example to automatically handle subtitles. The tracks are formatted in WebVTT format (.vtt files) — Web Video Text Tracks. */
-  "track": trackElement;
+  track: trackElement;
   /** @deprecated The <tt> HTML element creates inline text which is presented using the user agent's default monospace font face. This element was created for the purpose of rendering text as it would be displayed on a fixed-width display such as a teletype, text-only screen, or line printer. */
-  "tt": ttElement;
+  tt: ttElement;
   /** The <u> HTML element represents a span of inline text which should be rendered in a way that indicates that it has a non-textual annotation. This is rendered by default as a simple solid underline, but may be altered using CSS. */
-  "u": uElement;
+  u: uElement;
   /** The <ul> HTML element represents an unordered list of items, typically rendered as a bulleted list. */
-  "ul": ulElement;
+  ul: ulElement;
   /** The <var> HTML element represents the name of a variable in a mathematical expression or a programming context. It's typically presented using an italicized version of the current typeface, although that behavior is browser-dependent. */
-  "var": varElement;
+  var: varElement;
   /** The <video> HTML element embeds a media player which supports video playback into the document. You can use <video> for audio content as well, but the <audio> element may provide a more appropriate user experience. */
-  "video": videoElement;
+  video: videoElement;
   /** The <wbr> HTML element represents a word break opportunity—a position within text where the browser may optionally break a line, though its line-breaking rules would not otherwise create a break at that location. */
-  "wbr": wbrElement;
+  wbr: wbrElement;
   /** @deprecated The <xmp> HTML element renders text between the start and end tags without interpreting the HTML in between and using a monospaced font. The HTML2 specification recommended that it should be rendered wide enough to allow 80 characters per line. */
-  "xmp": xmpElement;
+  xmp: xmpElement;
 };
 
-type children = (string | TemplateStringsArray | HTMLElements[keyof HTMLElements])[];
+type children = (
+  | string
+  | TemplateStringsArray
+  | HTMLElements[keyof HTMLElements]
+)[];
 type GlobalHTMLAttributes<TagName extends keyof HTMLElements> = {
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-accesskey */
-  "accesskey": (value: string) => HTMLElements[TagName];
+  accesskey: (value: string) => HTMLElements[TagName];
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-autocapitalize */
-  "autocapitalize": (value: "off" | "on" | "none" | "sentences" | "words" | "characters") => HTMLElements[TagName];
+  autocapitalize: (
+    value: "off" | "on" | "none" | "sentences" | "words" | "characters"
+  ) => HTMLElements[TagName];
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-autofocus */
-  "autofocus": (value: boolean) => HTMLElements[TagName];
+  autofocus: (value: boolean) => HTMLElements[TagName];
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-contenteditable */
-  "contenteditable": (value: "" | "true" | "false") => HTMLElements[TagName];
+  contenteditable: (value: "" | "true" | "false") => HTMLElements[TagName];
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-dir */
-  "dir": (value: "ltr" | "rtl" | "auto") => HTMLElements[TagName];
+  dir: (value: "ltr" | "rtl" | "auto") => HTMLElements[TagName];
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-draggable */
-  "draggable": (value: "true" | "false") => HTMLElements[TagName];
+  draggable: (value: "true" | "false") => HTMLElements[TagName];
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-enterkeyhint */
-  "enterkeyhint": (value: "enter" | "done" | "go" | "next" | "previous" | "search" | "send") => HTMLElements[TagName];
+  enterkeyhint: (
+    value: "enter" | "done" | "go" | "next" | "previous" | "search" | "send"
+  ) => HTMLElements[TagName];
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-hidden */
-  "hidden": (value: boolean) => HTMLElements[TagName];
+  hidden: (value: boolean) => HTMLElements[TagName];
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-inert */
-  "inert": (value: boolean) => HTMLElements[TagName];
+  inert: (value: boolean) => HTMLElements[TagName];
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-inputmode */
-  "inputmode": (value: "none" | "text" | "tel" | "url" | "email" | "numeric" | "decimal" | "search") => HTMLElements[TagName];
+  inputmode: (
+    value:
+      | "none"
+      | "text"
+      | "tel"
+      | "url"
+      | "email"
+      | "numeric"
+      | "decimal"
+      | "search"
+  ) => HTMLElements[TagName];
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-is */
-  "is": (value: `${string}-${string}`) => HTMLElements[TagName];
+  is: (value: `${string}-${string}`) => HTMLElements[TagName];
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-itemid */
-  "itemid": (value: string) => HTMLElements[TagName];
+  itemid: (value: string) => HTMLElements[TagName];
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-itemprop */
-  "itemprop": (value: string) => HTMLElements[TagName];
+  itemprop: (value: string) => HTMLElements[TagName];
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-itemref */
-  "itemref": (value: string) => HTMLElements[TagName];
+  itemref: (value: string) => HTMLElements[TagName];
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-itemscope */
-  "itemscope": (value: boolean) => HTMLElements[TagName];
+  itemscope: (value: boolean) => HTMLElements[TagName];
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-itemtype */
-  "itemtype": (value: string) => HTMLElements[TagName];
+  itemtype: (value: string) => HTMLElements[TagName];
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-lang */
-  "lang": (value: string) => HTMLElements[TagName];
+  lang: (value: string) => HTMLElements[TagName];
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-nonce */
-  "nonce": (value: string) => HTMLElements[TagName];
+  nonce: (value: string) => HTMLElements[TagName];
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-spellcheck */
-  "spellcheck": (value: "" | "true" | "false") => HTMLElements[TagName];
+  spellcheck: (value: "" | "true" | "false") => HTMLElements[TagName];
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-style */
-  "style": (value: string) => HTMLElements[TagName];
+  style: (value: string) => HTMLElements[TagName];
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-tabindex */
-  "tabindex": (value: number) => HTMLElements[TagName];
+  tabindex: (value: number) => HTMLElements[TagName];
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-title */
-  "title": (value: string) => HTMLElements[TagName];
+  title: (value: string) => HTMLElements[TagName];
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-translate */
-  "translate": (value: "" | "yes" | "no") => HTMLElements[TagName];
+  translate: (value: "" | "yes" | "no") => HTMLElements[TagName];
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-class */
-  "class": (value: string) => HTMLElements[TagName];
+  class: (value: string) => HTMLElements[TagName];
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-id */
-  "id": (value: string) => HTMLElements[TagName];
+  id: (value: string) => HTMLElements[TagName];
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-slot */
-  "slot": (value: string) => HTMLElements[TagName];
+  slot: (value: string) => HTMLElements[TagName];
   /** @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-xmlns */
-  "xmlns": (value: string) => HTMLElements[TagName];
+  xmlns: (value: string) => HTMLElements[TagName];
   /** @deprecated @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-xml:lang */
   "xml:lang": (value: string) => HTMLElements[TagName];
   /** @deprecated @link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes#attr-xml:space */
   "xml:space": (value: "default" | "preserve") => HTMLElements[TagName];
-  [dataAttribute: `data${string}`]: (value: string | boolean | number) => HTMLElements[TagName];
-  (...children: children): string;
+  [dataAttribute: `data${string}`]: (
+    value: string | boolean | number
+  ) => HTMLElements[TagName];
+  (...children: children): HTMLElements[TagName];
 };
 
 type GlobalAriaAttributes<TagName extends keyof HTMLElements> = {
-  "ariaActivedescendant": (value: string) => HTMLElements[TagName];
-  "ariaAtomic": (value: string) => HTMLElements[TagName];
-  "ariaAutocomplete": (value: string) => HTMLElements[TagName];
-  "ariaBusy": (value: string) => HTMLElements[TagName];
-  "ariaChecked": (value: string) => HTMLElements[TagName];
-  "ariaColcount": (value: string) => HTMLElements[TagName];
-  "ariaColindex": (value: string) => HTMLElements[TagName];
-  "ariaColspan": (value: string) => HTMLElements[TagName];
-  "ariaControls": (value: string) => HTMLElements[TagName];
-  "ariaCurrent": (value: string) => HTMLElements[TagName];
-  "ariaDescribedby": (value: string) => HTMLElements[TagName];
-  "ariaDetails": (value: string) => HTMLElements[TagName];
-  "ariaDisabled": (value: string) => HTMLElements[TagName];
-  "ariaDropeffect": (value: string) => HTMLElements[TagName];
-  "ariaErrormessage": (value: string) => HTMLElements[TagName];
-  "ariaExpanded": (value: string) => HTMLElements[TagName];
-  "ariaFlowto": (value: string) => HTMLElements[TagName];
-  "ariaGrabbed": (value: string) => HTMLElements[TagName];
-  "ariaHaspopup": (value: string) => HTMLElements[TagName];
-  "ariaHidden": (value: string) => HTMLElements[TagName];
-  "ariaInvalid": (value: string) => HTMLElements[TagName];
-  "ariaKeyshortcuts": (value: string) => HTMLElements[TagName];
-  "ariaLabel": (value: string) => HTMLElements[TagName];
-  "ariaLabelledby": (value: string) => HTMLElements[TagName];
-  "ariaLevel": (value: string) => HTMLElements[TagName];
-  "ariaLive": (value: string) => HTMLElements[TagName];
-  "ariaModal": (value: string) => HTMLElements[TagName];
-  "ariaMultiline": (value: string) => HTMLElements[TagName];
-  "ariaMultiselectable": (value: string) => HTMLElements[TagName];
-  "ariaOrientation": (value: string) => HTMLElements[TagName];
-  "ariaOwns": (value: string) => HTMLElements[TagName];
-  "ariaPlaceholder": (value: string) => HTMLElements[TagName];
-  "ariaPosinset": (value: string) => HTMLElements[TagName];
-  "ariaPressed": (value: string) => HTMLElements[TagName];
-  "ariaReadonly": (value: string) => HTMLElements[TagName];
-  "ariaRelevant": (value: string) => HTMLElements[TagName];
-  "ariaRequired": (value: string) => HTMLElements[TagName];
-  "ariaRoledescription": (value: string) => HTMLElements[TagName];
-  "ariaRowcount": (value: string) => HTMLElements[TagName];
-  "ariaRowindex": (value: string) => HTMLElements[TagName];
-  "ariaRowspan": (value: string) => HTMLElements[TagName];
-  "ariaSelected": (value: string) => HTMLElements[TagName];
-  "ariaSetsize": (value: string) => HTMLElements[TagName];
-  "ariaSort": (value: string) => HTMLElements[TagName];
-  "ariaValuemax": (value: string) => HTMLElements[TagName];
-  "ariaValuemin": (value: string) => HTMLElements[TagName];
-  "ariaValuenow": (value: string) => HTMLElements[TagName];
-  "ariaValuetext": (value: string) => HTMLElements[TagName];
+  ariaActivedescendant: (value: string) => HTMLElements[TagName];
+  ariaAtomic: (value: string) => HTMLElements[TagName];
+  ariaAutocomplete: (value: string) => HTMLElements[TagName];
+  ariaBusy: (value: string) => HTMLElements[TagName];
+  ariaChecked: (value: string) => HTMLElements[TagName];
+  ariaColcount: (value: string) => HTMLElements[TagName];
+  ariaColindex: (value: string) => HTMLElements[TagName];
+  ariaColspan: (value: string) => HTMLElements[TagName];
+  ariaControls: (value: string) => HTMLElements[TagName];
+  ariaCurrent: (value: string) => HTMLElements[TagName];
+  ariaDescribedby: (value: string) => HTMLElements[TagName];
+  ariaDetails: (value: string) => HTMLElements[TagName];
+  ariaDisabled: (value: string) => HTMLElements[TagName];
+  ariaDropeffect: (value: string) => HTMLElements[TagName];
+  ariaErrormessage: (value: string) => HTMLElements[TagName];
+  ariaExpanded: (value: string) => HTMLElements[TagName];
+  ariaFlowto: (value: string) => HTMLElements[TagName];
+  ariaGrabbed: (value: string) => HTMLElements[TagName];
+  ariaHaspopup: (value: string) => HTMLElements[TagName];
+  ariaHidden: (value: string) => HTMLElements[TagName];
+  ariaInvalid: (value: string) => HTMLElements[TagName];
+  ariaKeyshortcuts: (value: string) => HTMLElements[TagName];
+  ariaLabel: (value: string) => HTMLElements[TagName];
+  ariaLabelledby: (value: string) => HTMLElements[TagName];
+  ariaLevel: (value: string) => HTMLElements[TagName];
+  ariaLive: (value: string) => HTMLElements[TagName];
+  ariaModal: (value: string) => HTMLElements[TagName];
+  ariaMultiline: (value: string) => HTMLElements[TagName];
+  ariaMultiselectable: (value: string) => HTMLElements[TagName];
+  ariaOrientation: (value: string) => HTMLElements[TagName];
+  ariaOwns: (value: string) => HTMLElements[TagName];
+  ariaPlaceholder: (value: string) => HTMLElements[TagName];
+  ariaPosinset: (value: string) => HTMLElements[TagName];
+  ariaPressed: (value: string) => HTMLElements[TagName];
+  ariaReadonly: (value: string) => HTMLElements[TagName];
+  ariaRelevant: (value: string) => HTMLElements[TagName];
+  ariaRequired: (value: string) => HTMLElements[TagName];
+  ariaRoledescription: (value: string) => HTMLElements[TagName];
+  ariaRowcount: (value: string) => HTMLElements[TagName];
+  ariaRowindex: (value: string) => HTMLElements[TagName];
+  ariaRowspan: (value: string) => HTMLElements[TagName];
+  ariaSelected: (value: string) => HTMLElements[TagName];
+  ariaSetsize: (value: string) => HTMLElements[TagName];
+  ariaSort: (value: string) => HTMLElements[TagName];
+  ariaValuemax: (value: string) => HTMLElements[TagName];
+  ariaValuemin: (value: string) => HTMLElements[TagName];
+  ariaValuenow: (value: string) => HTMLElements[TagName];
+  ariaValuetext: (value: string) => HTMLElements[TagName];
 };
 
 type aElement = {
   /** @deprecated Hinted at the character encoding of the linked URL. Note: This attribute is deprecated and should not be used by authors. Use the HTTP Content-Type header on the linked URL. */
-  "charset": (value: string) => HTMLElements["a"];
+  charset: (value: string) => HTMLElements["a"];
   /** @deprecated Used with the shape attribute. A comma-separated list of coordinates. */
-  "coords": (value: string) => HTMLElements["a"];
+  coords: (value: string) => HTMLElements["a"];
   /** Prompts the user to save the linked URL instead of navigating to it. Can be used with or without a value: Without a value, the browser will suggest a filename/extension, generated from various sources: The Content-Disposition HTTP header The final segment in the URL path The media type (from the Content-Type header, the start of a data: URL, or Blob.type for a blob: URL) Defining a value suggests it as the filename. / and \ characters are converted to underscores (_). Filesystems may forbid other characters in filenames, so browsers will adjust the suggested name if necessary. Note: download only works for same-origin URLs, or the blob: and data: schemes. If the Content-Disposition header has different information from the download attribute, resulting behavior may differ: If the header specifies a filename, it takes priority over a filename specified in the download attribute. If the header specifies a disposition of inline, Chrome, and Firefox 82 and later, prioritize the attribute and treat it as a download. Firefox versions before 82 prioritize the header and will display the content inline. */
-  "download": (value: string) => HTMLElements["a"];
+  download: (value: string) => HTMLElements["a"];
   /** The URL that the hyperlink points to. Links are not restricted to HTTP-based URLs — they can use any URL scheme supported by browsers: Sections of a page with fragment URLs Pieces of media files with media fragments Telephone numbers with tel: URLs Email addresses with mailto: URLs While web browsers may not support other URL schemes, web sites can with registerProtocolHandler() */
-  "href": (value: string) => HTMLElements["a"];
+  href: (value: string) => HTMLElements["a"];
   /** Hints at the human language of the linked URL. No built-in functionality. Allowed values are the same as the global lang attribute. */
-  "hreflang": (value: string) => HTMLElements["a"];
+  hreflang: (value: string) => HTMLElements["a"];
   /** @deprecated Was required to define a possible target location in a page. In HTML 4.01, id and name could both be used on <a>, as long as they had identical values. Note: Use the global attribute id instead. */
-  "name": (value: string) => HTMLElements["a"];
+  name: (value: string) => HTMLElements["a"];
   /** A space-separated list of URLs. When the link is followed, the browser will send POST requests with the body PING to the URLs. Typically for tracking. */
-  "ping": (value: string) => HTMLElements["a"];
+  ping: (value: string) => HTMLElements["a"];
   /** How much of the referrer to send when following the link. no-referrer: The Referer header will not be sent. no-referrer-when-downgrade: The Referer header will not be sent to origins without TLS (HTTPS). origin: The sent referrer will be limited to the origin of the referring page: its scheme, host, and port. origin-when-cross-origin: The referrer sent to other origins will be limited to the scheme, the host, and the port. Navigations on the same origin will still include the path. same-origin: A referrer will be sent for same origin, but cross-origin requests will contain no referrer information. strict-origin: Only send the origin of the document as the referrer when the protocol security level stays the same (HTTPS→HTTPS), but don't send it to a less secure destination (HTTPS→HTTP). strict-origin-when-cross-origin (default): Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP). unsafe-url: The referrer will include the origin and the path (but not the fragment, password, or username). This value is unsafe, because it leaks origins and paths from TLS-protected resources to insecure origins. */
-  "referrerpolicy": (value: "" | "no-referrer" | "no-referrer-when-downgrade" | "same-origin" | "origin" | "strict-origin" | "origin-when-cross-origin" | "strict-origin-when-cross-origin" | "unsafe-url") => HTMLElements["a"];
+  referrerpolicy: (
+    value:
+      | ""
+      | "no-referrer"
+      | "no-referrer-when-downgrade"
+      | "same-origin"
+      | "origin"
+      | "strict-origin"
+      | "origin-when-cross-origin"
+      | "strict-origin-when-cross-origin"
+      | "unsafe-url"
+  ) => HTMLElements["a"];
   /** The relationship of the linked URL as space-separated link types. */
-  "rel": (value: string) => HTMLElements["a"];
+  rel: (value: string) => HTMLElements["a"];
   /** @deprecated Specified a reverse link; the opposite of the rel attribute. Deprecated for being very confusing. */
-  "rev": (value: string) => HTMLElements["a"];
-  "role": (value: string) => HTMLElements["a"];
+  rev: (value: string) => HTMLElements["a"];
+  role: (value: string) => HTMLElements["a"];
   /** @deprecated The shape of the hyperlink's region in an image map. Note: Use the <area> element for image maps instead. */
-  "shape": (value: string) => HTMLElements["a"];
+  shape: (value: string) => HTMLElements["a"];
   /** Where to display the linked URL, as the name for a browsing context (a tab, window, or <iframe>). The following keywords have special meanings for where to load the URL: _self: the current browsing context. (Default) _blank: usually a new tab, but users can configure browsers to open a new window instead. _parent: the parent browsing context of the current one. If no parent, behaves as _self. _top: the topmost browsing context (the "highest" context that's an ancestor of the current one). If no ancestors, behaves as _self. Note: Setting target="_blank" on <a> elements implicitly provides the same rel behavior as setting rel="noopener" which does not set window.opener. See browser compatibility for support status. */
-  "target": (value: string) => HTMLElements["a"];
+  target: (value: string) => HTMLElements["a"];
   /** Hints at the linked URL's format with a MIME type. No built-in functionality. */
-  "type": (value: string) => HTMLElements["a"];
-} & GlobalAriaAttributes<"a"> & GlobalHTMLAttributes<"a">;
+  type: (value: string) => HTMLElements["a"];
+} & GlobalAriaAttributes<"a"> &
+  GlobalHTMLAttributes<"a">;
 
 type abbrElement = {
-  "role": (value: string) => HTMLElements["abbr"];
-} & GlobalAriaAttributes<"abbr"> & GlobalHTMLAttributes<"abbr">;
+  role: (value: string) => HTMLElements["abbr"];
+} & GlobalAriaAttributes<"abbr"> &
+  GlobalHTMLAttributes<"abbr">;
 
-type acronymElement = {
-} & GlobalAriaAttributes<"acronym"> & GlobalHTMLAttributes<"acronym">;
+type acronymElement = {} & GlobalAriaAttributes<"acronym"> &
+  GlobalHTMLAttributes<"acronym">;
 
 type addressElement = {
-  "role": (value: string) => HTMLElements["address"];
-} & GlobalAriaAttributes<"address"> & GlobalHTMLAttributes<"address">;
+  role: (value: string) => HTMLElements["address"];
+} & GlobalAriaAttributes<"address"> &
+  GlobalHTMLAttributes<"address">;
 
 type appletElement = {
   /** This attribute is used to position the applet on the page relative to content that might flow around it. The HTML 4.01 specification defines values of bottom, left, middle, right, and top, whereas Microsoft and Netscape also might support absbottom, absmiddle, baseline, center, and texttop. */
-  "align": (value: string) => HTMLElements["applet"];
+  align: (value: string) => HTMLElements["applet"];
   /** This attribute causes a descriptive text alternate to be displayed on browsers that do not support Java. Page designers should also remember that content enclosed within the <applet> element may also be rendered as alternative text. */
-  "alt": (value: string) => HTMLElements["applet"];
+  alt: (value: string) => HTMLElements["applet"];
   /** This attribute refers to an archived or compressed version of the applet and its associated class files, which might help reduce download time. */
-  "archive": (value: string) => HTMLElements["applet"];
+  archive: (value: string) => HTMLElements["applet"];
   /** This attribute specifies the URL of the applet's class file to be loaded and executed. Applet filenames are identified by a .class filename extension. The URL specified by code might be relative to the codebase attribute. */
-  "code": (value: string) => HTMLElements["applet"];
+  code: (value: string) => HTMLElements["applet"];
   /** This attribute gives the absolute or relative URL of the directory where applets' .class files referenced by the code attribute are stored. */
-  "codebase": (value: string) => HTMLElements["applet"];
+  codebase: (value: string) => HTMLElements["applet"];
   /** This attribute, supported by Internet Explorer 4 and higher, specifies the column name from the data source object that supplies the bound data. This attribute might be used to specify the various <param> elements passed to the Java applet. */
-  "datafld": (value: string) => HTMLElements["applet"];
+  datafld: (value: string) => HTMLElements["applet"];
   /** Like datafld, this attribute is used for data binding under Internet Explorer 4. It indicates the id of the data source object that supplies the data that is bound to the <param> elements associated with the applet. */
-  "datasrc": (value: string) => HTMLElements["applet"];
+  datasrc: (value: string) => HTMLElements["applet"];
   /** This attribute specifies the height, in pixels, that the applet needs. */
-  "height": (value: string) => HTMLElements["applet"];
+  height: (value: string) => HTMLElements["applet"];
   /** This attribute specifies additional horizontal space, in pixels, to be reserved on either side of the applet. */
-  "hspace": (value: string) => HTMLElements["applet"];
+  hspace: (value: string) => HTMLElements["applet"];
   /** In the Netscape implementation, this attribute allows access to an applet by programs in a scripting language embedded in the document. */
-  "mayscript": (value: string) => HTMLElements["applet"];
+  mayscript: (value: string) => HTMLElements["applet"];
   /** This attribute assigns a name to the applet so that it can be identified by other resources; particularly scripts. */
-  "name": (value: string) => HTMLElements["applet"];
+  name: (value: string) => HTMLElements["applet"];
   /** This attribute specifies the URL of a serialized representation of an applet. */
-  "object": (value: string) => HTMLElements["applet"];
+  object: (value: string) => HTMLElements["applet"];
   /** As defined for Internet Explorer 4 and higher, this attribute specifies a URL for an associated file for the applet. The meaning and use is unclear and not part of the HTML standard. */
-  "src": (value: string) => HTMLElements["applet"];
+  src: (value: string) => HTMLElements["applet"];
   /** This attribute specifies additional vertical space, in pixels, to be reserved above and below the applet. */
-  "vspace": (value: string) => HTMLElements["applet"];
+  vspace: (value: string) => HTMLElements["applet"];
   /** This attribute specifies in pixels the width that the applet needs. */
-  "width": (value: string) => HTMLElements["applet"];
-} & GlobalAriaAttributes<"applet"> & GlobalHTMLAttributes<"applet">;
+  width: (value: string) => HTMLElements["applet"];
+} & GlobalAriaAttributes<"applet"> &
+  GlobalHTMLAttributes<"applet">;
 
 type areaElement = {
-  "alt": (value: string) => HTMLElements["area"];
-  "coords": (value: string) => HTMLElements["area"];
+  alt: (value: string) => HTMLElements["area"];
+  coords: (value: string) => HTMLElements["area"];
   /** This attribute, if present, indicates that the author intends the hyperlink to be used for downloading a resource. See <a> for a full description of the download attribute. */
-  "download": (value: string) => HTMLElements["area"];
+  download: (value: string) => HTMLElements["area"];
   /** The hyperlink target for the area. Its value is a valid URL. This attribute may be omitted; if so, the <area> element does not represent a hyperlink. */
-  "href": (value: string) => HTMLElements["area"];
+  href: (value: string) => HTMLElements["area"];
   /** Indicates the language of the linked resource. Allowed values are defined by RFC 5646: Tags for Identifying Languages (also known as BCP 47). Use this attribute only if the href attribute is present. */
-  "hreflang": (value: string) => HTMLElements["area"];
+  hreflang: (value: string) => HTMLElements["area"];
   /** @deprecated Define a names for the clickable area so that it can be scripted by older browsers. */
-  "name": (value: string) => HTMLElements["area"];
+  name: (value: string) => HTMLElements["area"];
   /** @deprecated Indicates that no hyperlink exists for the associated area. Note: Since HTML5, omitting the href attribute is sufficient. */
-  "nohref": (value: string) => HTMLElements["area"];
+  nohref: (value: string) => HTMLElements["area"];
   /** Contains a space-separated list of URLs to which, when the hyperlink is followed, POST requests with the body PING will be sent by the browser (in the background). Typically used for tracking. */
-  "ping": (value: string) => HTMLElements["area"];
+  ping: (value: string) => HTMLElements["area"];
   /** A string indicating which referrer to use when fetching the resource: no-referrer: The Referer header will not be sent. no-referrer-when-downgrade: The Referer header will not be sent to origins without TLS (HTTPS). origin: The sent referrer will be limited to the origin of the referring page: its scheme, host, and port. origin-when-cross-origin: The referrer sent to other origins will be limited to the scheme, the host, and the port. Navigations on the same origin will still include the path. same-origin: A referrer will be sent for same origin, but cross-origin requests will contain no referrer information. strict-origin: Only send the origin of the document as the referrer when the protocol security level stays the same (HTTPS→HTTPS), but don't send it to a less secure destination (HTTPS→HTTP). strict-origin-when-cross-origin (default): Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP). unsafe-url: The referrer will include the origin and the path (but not the fragment, password, or username). This value is unsafe, because it leaks origins and paths from TLS-protected resources to insecure origins. */
-  "referrerpolicy": (value: "" | "no-referrer" | "no-referrer-when-downgrade" | "same-origin" | "origin" | "strict-origin" | "origin-when-cross-origin" | "strict-origin-when-cross-origin" | "unsafe-url") => HTMLElements["area"];
+  referrerpolicy: (
+    value:
+      | ""
+      | "no-referrer"
+      | "no-referrer-when-downgrade"
+      | "same-origin"
+      | "origin"
+      | "strict-origin"
+      | "origin-when-cross-origin"
+      | "strict-origin-when-cross-origin"
+      | "unsafe-url"
+  ) => HTMLElements["area"];
   /** For anchors containing the href attribute, this attribute specifies the relationship of the target object to the link object. The value is a space-separated list of link types values. The values and their semantics will be registered by some authority that might have meaning to the document author. The default relationship, if no other is given, is void. Use this attribute only if the href attribute is present. */
-  "rel": (value: string) => HTMLElements["area"];
-  "role": (value: string) => HTMLElements["area"];
-  "shape": (value: "rect" | "circle" | "poly" | "default") => HTMLElements["area"];
+  rel: (value: string) => HTMLElements["area"];
+  role: (value: string) => HTMLElements["area"];
+  shape: (
+    value: "rect" | "circle" | "poly" | "default"
+  ) => HTMLElements["area"];
   /** A keyword or author-defined name of the browsing context to display the linked resource. The following keywords have special meanings: _self (default): Show the resource in the current browsing context. _blank: Show the resource in a new, unnamed browsing context. _parent: Show the resource in the parent browsing context of the current one, if the current page is inside a frame. If there is no parent, acts the same as _self. _top: Show the resource in the topmost browsing context (the browsing context that is an ancestor of the current one and has no parent). If there is no parent, acts the same as _self. Use this attribute only if the href attribute is present. Note: Setting target="_blank" on <area> elements implicitly provides the same rel behavior as setting rel="noopener" which does not set window.opener. See browser compatibility for support status. */
-  "target": (value: string) => HTMLElements["area"];
+  target: (value: string) => HTMLElements["area"];
   /** @deprecated Hint for the type of the referenced resource. Ignored by browsers. */
-  "type": (value: string) => HTMLElements["area"];
-} & GlobalAriaAttributes<"area"> & GlobalHTMLAttributes<"area">;
+  type: (value: string) => HTMLElements["area"];
+} & GlobalAriaAttributes<"area"> &
+  GlobalHTMLAttributes<"area">;
 
 type articleElement = {
-  "role": (value: string) => HTMLElements["article"];
-} & GlobalAriaAttributes<"article"> & GlobalHTMLAttributes<"article">;
+  role: (value: string) => HTMLElements["article"];
+} & GlobalAriaAttributes<"article"> &
+  GlobalHTMLAttributes<"article">;
 
 type asideElement = {
-  "role": (value: string) => HTMLElements["aside"];
-} & GlobalAriaAttributes<"aside"> & GlobalHTMLAttributes<"aside">;
+  role: (value: string) => HTMLElements["aside"];
+} & GlobalAriaAttributes<"aside"> &
+  GlobalHTMLAttributes<"aside">;
 
 type audioElement = {
   /** A Boolean attribute: if specified, the audio will automatically begin playback as soon as it can do so, without waiting for the entire audio file to finish downloading. Note: Sites that automatically play audio (or videos with an audio track) can be an unpleasant experience for users, so should be avoided when possible. If you must offer autoplay functionality, you should make it opt-in (requiring a user to specifically enable it). However, this can be useful when creating media elements whose source will be set at a later time, under user control. See our autoplay guide for additional information about how to properly use autoplay. */
-  "autoplay": (value: boolean) => HTMLElements["audio"];
+  autoplay: (value: boolean) => HTMLElements["audio"];
   /** If this attribute is present, the browser will offer controls to allow the user to control audio playback, including volume, seeking, and pause/resume playback. */
-  "controls": (value: boolean) => HTMLElements["audio"];
+  controls: (value: boolean) => HTMLElements["audio"];
   /** This enumerated attribute indicates whether to use CORS to fetch the related audio file. CORS-enabled resources can be reused in the <canvas> element without being tainted. The allowed values are: anonymous Sends a cross-origin request without a credential. In other words, it sends the Origin: HTTP header without a cookie, X.509 certificate, or performing HTTP Basic authentication. If the server does not give credentials to the origin site (by not setting the Access-Control-Allow-Origin: HTTP header), the image will be tainted, and its usage restricted. use-credentials Sends a cross-origin request with a credential. In other words, it sends the Origin: HTTP header with a cookie, a certificate, or performing HTTP Basic authentication. If the server does not give credentials to the origin site (through Access-Control-Allow-Credentials: HTTP header), the image will be tainted and its usage restricted. When not present, the resource is fetched without a CORS request (i.e. without sending the Origin: HTTP header), preventing its non-tainted used in <canvas> elements. If invalid, it is handled as if the enumerated keyword anonymous was used. See CORS settings attributes for additional information. */
-  "crossorigin": (value: "" | "anonymous" | "use-credentials") => HTMLElements["audio"];
+  crossorigin: (
+    value: "" | "anonymous" | "use-credentials"
+  ) => HTMLElements["audio"];
   /** A Boolean attribute used to disable the capability of remote playback in devices that are attached using wired (HDMI, DVI, etc.) and wireless technologies (Miracast, Chromecast, DLNA, AirPlay, etc). See this proposed specification for more information. Note: In Safari, you can use x-webkit-airplay="deny" as a fallback. */
-  "disableremoteplayback": (value: string) => HTMLElements["audio"];
+  disableremoteplayback: (value: string) => HTMLElements["audio"];
   /** A Boolean attribute: if specified, the audio player will automatically seek back to the start upon reaching the end of the audio. */
-  "loop": (value: boolean) => HTMLElements["audio"];
+  loop: (value: boolean) => HTMLElements["audio"];
   /** A Boolean attribute that indicates whether the audio will be initially silenced. Its default value is false. */
-  "muted": (value: boolean) => HTMLElements["audio"];
+  muted: (value: boolean) => HTMLElements["audio"];
   /** This enumerated attribute is intended to provide a hint to the browser about what the author thinks will lead to the best user experience. It may have one of the following values: none: Indicates that the audio should not be preloaded. metadata: Indicates that only audio metadata (e.g. length) is fetched. auto: Indicates that the whole audio file can be downloaded, even if the user is not expected to use it. empty string: A synonym of the auto value. The default value is different for each browser. The spec advises it to be set to metadata. Note: The autoplay attribute has precedence over preload. If autoplay is specified, the browser would obviously need to start downloading the audio for playback. The browser is not forced by the specification to follow the value of this attribute; it is a mere hint. */
-  "preload": (value: "none" | "metadata" | "auto") => HTMLElements["audio"];
-  "role": (value: string) => HTMLElements["audio"];
+  preload: (value: "none" | "metadata" | "auto") => HTMLElements["audio"];
+  role: (value: string) => HTMLElements["audio"];
   /** The URL of the audio to embed. This is subject to HTTP access controls. This is optional; you may instead use the <source> element within the audio block to specify the audio to embed. */
-  "src": (value: string) => HTMLElements["audio"];
-} & GlobalAriaAttributes<"audio"> & GlobalHTMLAttributes<"audio">;
+  src: (value: string) => HTMLElements["audio"];
+} & GlobalAriaAttributes<"audio"> &
+  GlobalHTMLAttributes<"audio">;
 
 type bElement = {
-  "role": (value: string) => HTMLElements["b"];
-} & GlobalAriaAttributes<"b"> & GlobalHTMLAttributes<"b">;
+  role: (value: string) => HTMLElements["b"];
+} & GlobalAriaAttributes<"b"> &
+  GlobalHTMLAttributes<"b">;
 
 type baseElement = {
   /** The base URL to be used throughout the document for relative URLs. Absolute and relative URLs are allowed. */
-  "href": (value: string) => HTMLElements["base"];
-  "role": (value: string) => HTMLElements["base"];
+  href: (value: string) => HTMLElements["base"];
+  role: (value: string) => HTMLElements["base"];
   /** A keyword or author-defined name of the default browsing context to show the results of navigation from <a>, <area>, or <form> elements without explicit target attributes. The following keywords have special meanings: _self (default): Show the result in the current browsing context. _blank: Show the result in a new, unnamed browsing context. _parent: Show the result in the parent browsing context of the current one, if the current page is inside a frame. If there is no parent, acts the same as _self. _top: Show the result in the topmost browsing context (the browsing context that is an ancestor of the current one and has no parent). If there is no parent, acts the same as _self. */
-  "target": (value: string) => HTMLElements["base"];
-} & GlobalAriaAttributes<"base"> & GlobalHTMLAttributes<"base">;
+  target: (value: string) => HTMLElements["base"];
+} & GlobalAriaAttributes<"base"> &
+  GlobalHTMLAttributes<"base">;
 
 type basefontElement = {
   /** This attribute sets the text color using either a named color or a color specified in the hexadecimal #RRGGBB format. */
-  "color": (value: string) => HTMLElements["basefont"];
+  color: (value: string) => HTMLElements["basefont"];
   /** This attribute contains a list of one or more font names. The document text in the default style is rendered in the first font face that the client's browser supports. If no font listed is installed on the local system, the browser typically defaults to the proportional or fixed-width font for that system. */
-  "face": (value: string) => HTMLElements["basefont"];
+  face: (value: string) => HTMLElements["basefont"];
   /** This attribute specifies the font size as either a numeric or relative value. Numeric values range from 1 to 7 with 1 being the smallest and 3 the default. */
-  "size": (value: string) => HTMLElements["basefont"];
-} & GlobalAriaAttributes<"basefont"> & GlobalHTMLAttributes<"basefont">;
+  size: (value: string) => HTMLElements["basefont"];
+} & GlobalAriaAttributes<"basefont"> &
+  GlobalHTMLAttributes<"basefont">;
 
 type bdiElement = {
-  "role": (value: string) => HTMLElements["bdi"];
-} & GlobalAriaAttributes<"bdi"> & GlobalHTMLAttributes<"bdi">;
+  role: (value: string) => HTMLElements["bdi"];
+} & GlobalAriaAttributes<"bdi"> &
+  GlobalHTMLAttributes<"bdi">;
 
 type bdoElement = {
-  "role": (value: string) => HTMLElements["bdo"];
-} & GlobalAriaAttributes<"bdo"> & GlobalHTMLAttributes<"bdo">;
+  role: (value: string) => HTMLElements["bdo"];
+} & GlobalAriaAttributes<"bdo"> &
+  GlobalHTMLAttributes<"bdo">;
 
 type bgsoundElement = {
   /** This attribute defines a number between -10,000 and +10,000 that determines how the volume will be divided between the speakers. */
-  "balance": (value: string) => HTMLElements["bgsound"];
+  balance: (value: string) => HTMLElements["bgsound"];
   /** This attribute indicates the number of times a sound is to be played and either has a numeric value or the keyword infinite. */
-  "loop": (value: string) => HTMLElements["bgsound"];
+  loop: (value: string) => HTMLElements["bgsound"];
   /** This attribute specifies the URL of the sound file to be played, which must be one of the following types: .wav, .au, or .mid. */
-  "src": (value: string) => HTMLElements["bgsound"];
+  src: (value: string) => HTMLElements["bgsound"];
   /** This attribute defines a number between -10,000 and 0 that determines the loudness of a page's background sound. */
-  "volume": (value: string) => HTMLElements["bgsound"];
-} & GlobalAriaAttributes<"bgsound"> & GlobalHTMLAttributes<"bgsound">;
+  volume: (value: string) => HTMLElements["bgsound"];
+} & GlobalAriaAttributes<"bgsound"> &
+  GlobalHTMLAttributes<"bgsound">;
 
-type bigElement = {
-} & GlobalAriaAttributes<"big"> & GlobalHTMLAttributes<"big">;
+type bigElement = {} & GlobalAriaAttributes<"big"> &
+  GlobalHTMLAttributes<"big">;
 
-type blinkElement = {
-} & GlobalAriaAttributes<"blink"> & GlobalHTMLAttributes<"blink">;
+type blinkElement = {} & GlobalAriaAttributes<"blink"> &
+  GlobalHTMLAttributes<"blink">;
 
 type blockquoteElement = {
-  "cite": (value: string) => HTMLElements["blockquote"];
-  "role": (value: string) => HTMLElements["blockquote"];
-} & GlobalAriaAttributes<"blockquote"> & GlobalHTMLAttributes<"blockquote">;
+  cite: (value: string) => HTMLElements["blockquote"];
+  role: (value: string) => HTMLElements["blockquote"];
+} & GlobalAriaAttributes<"blockquote"> &
+  GlobalHTMLAttributes<"blockquote">;
 
 type bodyElement = {
   /** @deprecated Color of text for hyperlinks when selected. This method is non-conforming, use CSS color property in conjunction with the :active pseudo-class instead. */
-  "alink": (value: string) => HTMLElements["body"];
+  alink: (value: string) => HTMLElements["body"];
   /** @deprecated URI of a image to use as a background. This method is non-conforming, use CSS background property on the element instead. */
-  "background": (value: string) => HTMLElements["body"];
+  background: (value: string) => HTMLElements["body"];
   /** @deprecated Background color for the document. This method is non-conforming, use CSS background-color property on the element instead. */
-  "bgcolor": (value: string) => HTMLElements["body"];
+  bgcolor: (value: string) => HTMLElements["body"];
   /** @deprecated The margin of the bottom of the body. This method is non-conforming, use CSS margin-bottom property on the element instead. */
-  "bottommargin": (value: string) => HTMLElements["body"];
+  bottommargin: (value: string) => HTMLElements["body"];
   /** @deprecated The margin of the left of the body. This method is non-conforming, use CSS margin-left property on the element instead. */
-  "leftmargin": (value: string) => HTMLElements["body"];
+  leftmargin: (value: string) => HTMLElements["body"];
   /** @deprecated Color of text for unvisited hypertext links. This method is non-conforming, use CSS color property in conjunction with the :link pseudo-class instead. */
-  "link": (value: string) => HTMLElements["body"];
+  link: (value: string) => HTMLElements["body"];
   /** Function to call when the user has moved forward in undo transaction history. */
-  "onredo": (value: string) => HTMLElements["body"];
+  onredo: (value: string) => HTMLElements["body"];
   /** Function to call when the user has moved backward in undo transaction history. */
-  "onundo": (value: string) => HTMLElements["body"];
+  onundo: (value: string) => HTMLElements["body"];
   /** @deprecated The margin of the right of the body. This method is non-conforming, use CSS margin-right property on the element instead. */
-  "rightmargin": (value: string) => HTMLElements["body"];
-  "role": (value: string) => HTMLElements["body"];
+  rightmargin: (value: string) => HTMLElements["body"];
+  role: (value: string) => HTMLElements["body"];
   /** @deprecated Foreground color of text. This method is non-conforming, use CSS color property on the element instead. */
-  "text": (value: string) => HTMLElements["body"];
+  text: (value: string) => HTMLElements["body"];
   /** @deprecated The margin of the top of the body. This method is non-conforming, use CSS margin-top property on the element instead. */
-  "topmargin": (value: string) => HTMLElements["body"];
+  topmargin: (value: string) => HTMLElements["body"];
   /** @deprecated Color of text for visited hypertext links. This method is non-conforming, use CSS color property in conjunction with the :visited pseudo-class instead. */
-  "vlink": (value: string) => HTMLElements["body"];
-} & GlobalAriaAttributes<"body"> & GlobalHTMLAttributes<"body">;
+  vlink: (value: string) => HTMLElements["body"];
+} & GlobalAriaAttributes<"body"> &
+  GlobalHTMLAttributes<"body">;
 
 type brElement = {
   /** @deprecated Indicates where to begin the next line after the break. */
-  "clear": (value: string) => HTMLElements["br"];
-  "role": (value: string) => HTMLElements["br"];
-} & GlobalAriaAttributes<"br"> & GlobalHTMLAttributes<"br">;
+  clear: (value: string) => HTMLElements["br"];
+  role: (value: string) => HTMLElements["br"];
+} & GlobalAriaAttributes<"br"> &
+  GlobalHTMLAttributes<"br">;
 
 type buttonElement = {
   /** This attribute on a <button> is nonstandard and Firefox-specific. Unlike other browsers, Firefox persists the dynamic disabled state of a <button> across page loads. Setting autocomplete="off" on the button disables this feature; see bug 654072. */
-  "autocomplete": (value: string) => HTMLElements["button"];
+  autocomplete: (value: string) => HTMLElements["button"];
   /** This Boolean attribute prevents the user from interacting with the button: it cannot be pressed or focused. Firefox, unlike other browsers, persists the dynamic disabled state of a <button> across page loads. Use the autocomplete attribute to control this feature. */
-  "disabled": (value: boolean) => HTMLElements["button"];
+  disabled: (value: boolean) => HTMLElements["button"];
   /** The <form> element to associate the button with (its form owner). The value of this attribute must be the id of a <form> in the same document. (If this attribute is not set, the <button> is associated with its ancestor <form> element, if any.) This attribute lets you associate <button> elements to <form>s anywhere in the document, not just inside a <form>. It can also override an ancestor <form> element. */
-  "form": (value: string) => HTMLElements["button"];
+  form: (value: string) => HTMLElements["button"];
   /** The URL that processes the information submitted by the button. Overrides the action attribute of the button's form owner. Does nothing if there is no form owner. */
-  "formaction": (value: string) => HTMLElements["button"];
+  formaction: (value: string) => HTMLElements["button"];
   /** If the button is a submit button (it's inside/associated with a <form> and doesn't have type="button"), specifies how to encode the form data that is submitted. Possible values: application/x-www-form-urlencoded: The default if the attribute is not used. multipart/form-data: Use to submit <input> elements with their type attributes set to file. text/plain: Specified as a debugging aid; shouldn't be used for real form submission. If this attribute is specified, it overrides the enctype attribute of the button's form owner. */
-  "formenctype": (value: "application/x-www-form-urlencoded" | "multipart/form-data" | "text/plain") => HTMLElements["button"];
+  formenctype: (
+    value:
+      | "application/x-www-form-urlencoded"
+      | "multipart/form-data"
+      | "text/plain"
+  ) => HTMLElements["button"];
   /** If the button is a submit button (it's inside/associated with a <form> and doesn't have type="button"), this attribute specifies the HTTP method used to submit the form. Possible values: post: The data from the form are included in the body of the HTTP request when sent to the server. Use when the form contains information that shouldn't be public, like login credentials. get: The form data are appended to the form's action URL, with a ? as a separator, and the resulting URL is sent to the server. Use this method when the form has no side effects, like search forms. If specified, this attribute overrides the method attribute of the button's form owner. */
-  "formmethod": (value: "post" | "get" | "dialog") => HTMLElements["button"];
+  formmethod: (value: "post" | "get" | "dialog") => HTMLElements["button"];
   /** If the button is a submit button, this Boolean attribute specifies that the form is not to be validated when it is submitted. If this attribute is specified, it overrides the novalidate attribute of the button's form owner. This attribute is also available on <input type="image"> and <input type="submit"> elements. */
-  "formnovalidate": (value: boolean) => HTMLElements["button"];
+  formnovalidate: (value: boolean) => HTMLElements["button"];
   /** If the button is a submit button, this attribute is an author-defined name or standardized, underscore-prefixed keyword indicating where to display the response from submitting the form. This is the name of, or keyword for, a browsing context (a tab, window, or <iframe>). If this attribute is specified, it overrides the target attribute of the button's form owner. The following keywords have special meanings: _self: Load the response into the same browsing context as the current one. This is the default if the attribute is not specified. _blank: Load the response into a new unnamed browsing context — usually a new tab or window, depending on the user's browser settings. _parent: Load the response into the parent browsing context of the current one. If there is no parent, this option behaves the same way as _self. _top: Load the response into the top-level browsing context (that is, the browsing context that is an ancestor of the current one, and has no parent). If there is no parent, this option behaves the same way as _self. */
-  "formtarget": (value: string) => HTMLElements["button"];
+  formtarget: (value: string) => HTMLElements["button"];
   /** The name of the button, submitted as a pair with the button's value as part of the form data, when that button is used to submit the form. */
-  "name": (value: string) => HTMLElements["button"];
-  "role": (value: string) => HTMLElements["button"];
-  "type": (value: "submit" | "reset" | "button") => HTMLElements["button"];
-  "value": (value: string) => HTMLElements["button"];
-} & GlobalAriaAttributes<"button"> & GlobalHTMLAttributes<"button">;
+  name: (value: string) => HTMLElements["button"];
+  role: (value: string) => HTMLElements["button"];
+  type: (value: "submit" | "reset" | "button") => HTMLElements["button"];
+  value: (value: string) => HTMLElements["button"];
+} & GlobalAriaAttributes<"button"> &
+  GlobalHTMLAttributes<"button">;
 
 type canvasElement = {
-  "height": (value: number) => HTMLElements["canvas"];
+  height: (value: number) => HTMLElements["canvas"];
   /** @deprecated Lets the canvas know whether or not translucency will be a factor. If the canvas knows there's no translucency, painting performance can be optimized. This is only supported by Mozilla-based browsers; use the standardized canvas.getContext('2d', { alpha: false }) instead. */
-  "mozOpaque": (value: string) => HTMLElements["canvas"];
-  "role": (value: string) => HTMLElements["canvas"];
-  "width": (value: number) => HTMLElements["canvas"];
-} & GlobalAriaAttributes<"canvas"> & GlobalHTMLAttributes<"canvas">;
+  mozOpaque: (value: string) => HTMLElements["canvas"];
+  role: (value: string) => HTMLElements["canvas"];
+  width: (value: number) => HTMLElements["canvas"];
+} & GlobalAriaAttributes<"canvas"> &
+  GlobalHTMLAttributes<"canvas">;
 
 type captionElement = {
   /** @deprecated This enumerated attribute indicates how the caption must be aligned with respect to the table. It may have one of the following values: left The caption is displayed to the left of the table. top The caption is displayed above the table. right The caption is displayed to the right of the table. bottom The caption is displayed below the table. Warning: Do not use this attribute, as it has been deprecated. The <caption> element should be styled using the CSS properties caption-side and text-align. */
-  "align": (value: string) => HTMLElements["caption"];
-  "role": (value: string) => HTMLElements["caption"];
-} & GlobalAriaAttributes<"caption"> & GlobalHTMLAttributes<"caption">;
+  align: (value: string) => HTMLElements["caption"];
+  role: (value: string) => HTMLElements["caption"];
+} & GlobalAriaAttributes<"caption"> &
+  GlobalHTMLAttributes<"caption">;
 
-type centerElement = {
-} & GlobalAriaAttributes<"center"> & GlobalHTMLAttributes<"center">;
+type centerElement = {} & GlobalAriaAttributes<"center"> &
+  GlobalHTMLAttributes<"center">;
 
 type citeElement = {
-  "role": (value: string) => HTMLElements["cite"];
-} & GlobalAriaAttributes<"cite"> & GlobalHTMLAttributes<"cite">;
+  role: (value: string) => HTMLElements["cite"];
+} & GlobalAriaAttributes<"cite"> &
+  GlobalHTMLAttributes<"cite">;
 
 type codeElement = {
-  "role": (value: string) => HTMLElements["code"];
-} & GlobalAriaAttributes<"code"> & GlobalHTMLAttributes<"code">;
+  role: (value: string) => HTMLElements["code"];
+} & GlobalAriaAttributes<"code"> &
+  GlobalHTMLAttributes<"code">;
 
 type colElement = {
   /** @deprecated This enumerated attribute specifies how horizontal alignment of each column cell content will be handled. Possible values are: left, aligning the content to the left of the cell center, centering the content in the cell right, aligning the content to the right of the cell justify, inserting spaces into the textual content so that the content is justified in the cell If this attribute is not set, its value is inherited from the align of the <colgroup> element this <col> element belongs too. If there are none, the left value is assumed. Note: To achieve the same effect as the left, center, right or justify values, do not try to set the text-align property on a selector giving a <col> element. Because <td> elements are not descendant of the <col> element, they won't inherit it. If the table doesn't use a colspan attribute, use the td:nth-child(an+b) CSS selector. Set a to zero and b to the position of the column in the table, e.g. td:nth-child(2) { text-align: right; } to right-align the second column. If the table does use a colspan attribute, the effect can be achieved by combining adequate CSS attribute selectors like [colspan=n], though this is not trivial. */
-  "align": (value: string) => HTMLElements["col"];
+  align: (value: string) => HTMLElements["col"];
   /** @deprecated The background color of the table. It is a 6-digit hexadecimal RGB code, prefixed by a '#'. One of the predefined color keywords can also be used. To achieve a similar effect, use the CSS background-color property. */
-  "bgcolor": (value: string) => HTMLElements["col"];
+  bgcolor: (value: string) => HTMLElements["col"];
   /** @deprecated This attribute is used to set the character to align the cells in a column on. Typical values for this include a period (.) when attempting to align numbers or monetary values. If align is not set to char, this attribute is ignored. */
-  "char": (value: string) => HTMLElements["col"];
+  char: (value: string) => HTMLElements["col"];
   /** @deprecated This attribute is used to indicate the number of characters to offset the column data from the alignment characters specified by the char attribute. */
-  "charoff": (value: string) => HTMLElements["col"];
-  "role": (value: string) => HTMLElements["col"];
-  "span": (value: string) => HTMLElements["col"];
+  charoff: (value: string) => HTMLElements["col"];
+  role: (value: string) => HTMLElements["col"];
+  span: (value: string) => HTMLElements["col"];
   /** @deprecated This attribute specifies the vertical alignment of the text within each cell of the column. Possible values for this attribute are: baseline, which will put the text as close to the bottom of the cell as it is possible, but align it on the baseline of the characters instead of the bottom of them. If characters are all of the size, this has the same effect as bottom. bottom, which will put the text as close to the bottom of the cell as it is possible; middle, which will center the text in the cell; and top, which will put the text as close to the top of the cell as it is possible. Note: Do not try to set the vertical-align property on a selector giving a <col> element. Because <td> elements are not descendant of the <col> element, they won't inherit it. If the table doesn't use a colspan attribute, use the td:nth-child(an+b) CSS selector where a is the total number of the columns in the table and b is the ordinal position of the column in the table. Only after this selector the vertical-align property can be used. If the table does use a colspan attribute, the effect can be achieved by combining adequate CSS attribute selectors like [colspan=n], though this is not trivial. */
-  "valign": (value: string) => HTMLElements["col"];
+  valign: (value: string) => HTMLElements["col"];
   /** @deprecated This attribute specifies a default width for each column in the current column group. In addition to the standard pixel and percentage values, this attribute might take the special form 0*, which means that the width of each column in the group should be the minimum width necessary to hold the column's contents. Relative widths such as 5* also can be used. */
-  "width": (value: string) => HTMLElements["col"];
-} & GlobalAriaAttributes<"col"> & GlobalHTMLAttributes<"col">;
+  width: (value: string) => HTMLElements["col"];
+} & GlobalAriaAttributes<"col"> &
+  GlobalHTMLAttributes<"col">;
 
 type colgroupElement = {
   /** @deprecated This enumerated attribute specifies how horizontal alignment of each column cell content will be handled. Possible values are: left, aligning the content to the left of the cell center, centering the content in the cell right, aligning the content to the right of the cell justify, inserting spaces into the textual content so that the content is justified in the cell char, aligning the textual content on a special character with a minimal offset, defined by the char and charoff attributes. If this attribute is not set, the left value is assumed. The descendant <col> elements may override this value using their own align attribute. Note: Do not try to set the text-align property on a selector giving a <colgroup> element. Because <td> elements are not descendant of the <colgroup> element, they won't inherit it. If the table doesn't use a colspan attribute, use one td:nth-child(an+b) CSS selector per column, where a is the total number of the columns in the table and b is the ordinal position of this column in the table. Only after this selector the text-align property can be used. If the table does use a colspan attribute, the effect can be achieved by combining adequate CSS attribute selectors like [colspan=n], though this is not trivial. */
-  "align": (value: string) => HTMLElements["colgroup"];
+  align: (value: string) => HTMLElements["colgroup"];
   /** @deprecated The background color of the table. It is a 6-digit hexadecimal RGB code, prefixed by a '#'. One of the predefined color keywords can also be used. To achieve a similar effect, use the CSS background-color property. */
-  "bgcolor": (value: string) => HTMLElements["colgroup"];
+  bgcolor: (value: string) => HTMLElements["colgroup"];
   /** @deprecated This attribute specifies the alignment of the content in a column group to a character. Typical values for this include a period (.) when attempting to align numbers or monetary values. If align is not set to char, this attribute is ignored, though it will still be used as the default value for the align of the <col> which are members of this column group. */
-  "char": (value: string) => HTMLElements["colgroup"];
+  char: (value: string) => HTMLElements["colgroup"];
   /** @deprecated This attribute is used to indicate the number of characters to offset the column data from the alignment character specified by the char attribute. */
-  "charoff": (value: string) => HTMLElements["colgroup"];
-  "role": (value: string) => HTMLElements["colgroup"];
-  "span": (value: string) => HTMLElements["colgroup"];
+  charoff: (value: string) => HTMLElements["colgroup"];
+  role: (value: string) => HTMLElements["colgroup"];
+  span: (value: string) => HTMLElements["colgroup"];
   /** @deprecated This attribute specifies the vertical alignment of the text within each cell of the column. Possible values for this attribute are: baseline, which will put the text as close to the bottom of the cell as it is possible, but align it on the baseline of the characters instead of the bottom of them. If characters are all of the size, this has the same effect as bottom. bottom, which will put the text as close to the bottom of the cell as it is possible; middle, which will center the text in the cell; and top, which will put the text as close to the top of the cell as it is possible. Note: Do not try to set the vertical-align property on a selector giving a <colgroup> element. Because <td> elements are not descendant of the <colgroup> element, they won't inherit it. If the table doesn't use a colspan attribute, use the td:nth-child(an+b) CSS selector per column, where a is the total number of the columns in the table and b is the ordinal position of the column in the table. Only after this selector the vertical-align property can be used. If the table does use a colspan attribute, the effect can be achieved by combining adequate CSS attribute selectors like [colspan=n], though this is not trivial. */
-  "valign": (value: string) => HTMLElements["colgroup"];
-} & GlobalAriaAttributes<"colgroup"> & GlobalHTMLAttributes<"colgroup">;
+  valign: (value: string) => HTMLElements["colgroup"];
+} & GlobalAriaAttributes<"colgroup"> &
+  GlobalHTMLAttributes<"colgroup">;
 
 type contentElement = {
   /** A comma-separated list of selectors. These have the same syntax as CSS selectors. They select the content to insert in place of the <content> element. */
-  "select": (value: string) => HTMLElements["content"];
-} & GlobalAriaAttributes<"content"> & GlobalHTMLAttributes<"content">;
+  select: (value: string) => HTMLElements["content"];
+} & GlobalAriaAttributes<"content"> &
+  GlobalHTMLAttributes<"content">;
 
 type dataElement = {
-  "role": (value: string) => HTMLElements["data"];
-  "value": (value: string) => HTMLElements["data"];
-} & GlobalAriaAttributes<"data"> & GlobalHTMLAttributes<"data">;
+  role: (value: string) => HTMLElements["data"];
+  value: (value: string) => HTMLElements["data"];
+} & GlobalAriaAttributes<"data"> &
+  GlobalHTMLAttributes<"data">;
 
 type datalistElement = {
-  "role": (value: string) => HTMLElements["datalist"];
-} & GlobalAriaAttributes<"datalist"> & GlobalHTMLAttributes<"datalist">;
+  role: (value: string) => HTMLElements["datalist"];
+} & GlobalAriaAttributes<"datalist"> &
+  GlobalHTMLAttributes<"datalist">;
 
 type ddElement = {
   /** If the value of this attribute is set to yes, the definition text will not wrap. The default value is no. */
-  "nowrap": (value: string) => HTMLElements["dd"];
-  "role": (value: string) => HTMLElements["dd"];
-} & GlobalAriaAttributes<"dd"> & GlobalHTMLAttributes<"dd">;
+  nowrap: (value: string) => HTMLElements["dd"];
+  role: (value: string) => HTMLElements["dd"];
+} & GlobalAriaAttributes<"dd"> &
+  GlobalHTMLAttributes<"dd">;
 
 type delElement = {
-  "cite": (value: string) => HTMLElements["del"];
-  "datetime": (value: string) => HTMLElements["del"];
-  "role": (value: string) => HTMLElements["del"];
-} & GlobalAriaAttributes<"del"> & GlobalHTMLAttributes<"del">;
+  cite: (value: string) => HTMLElements["del"];
+  datetime: (value: string) => HTMLElements["del"];
+  role: (value: string) => HTMLElements["del"];
+} & GlobalAriaAttributes<"del"> &
+  GlobalHTMLAttributes<"del">;
 
 type detailsElement = {
-  "open": (value: boolean) => HTMLElements["details"];
-  "role": (value: string) => HTMLElements["details"];
-} & GlobalAriaAttributes<"details"> & GlobalHTMLAttributes<"details">;
+  open: (value: boolean) => HTMLElements["details"];
+  role: (value: string) => HTMLElements["details"];
+} & GlobalAriaAttributes<"details"> &
+  GlobalHTMLAttributes<"details">;
 
 type dfnElement = {
-  "role": (value: string) => HTMLElements["dfn"];
-} & GlobalAriaAttributes<"dfn"> & GlobalHTMLAttributes<"dfn">;
+  role: (value: string) => HTMLElements["dfn"];
+} & GlobalAriaAttributes<"dfn"> &
+  GlobalHTMLAttributes<"dfn">;
 
 type dialogElement = {
-  "open": (value: boolean) => HTMLElements["dialog"];
-  "role": (value: string) => HTMLElements["dialog"];
-} & GlobalAriaAttributes<"dialog"> & GlobalHTMLAttributes<"dialog">;
+  open: (value: boolean) => HTMLElements["dialog"];
+  role: (value: string) => HTMLElements["dialog"];
+} & GlobalAriaAttributes<"dialog"> &
+  GlobalHTMLAttributes<"dialog">;
 
 type dirElement = {
   /** This Boolean attribute hints that the list should be rendered in a compact style. The interpretation of this attribute depends on the user agent and it doesn't work in all browsers. */
-  "compact": (value: string) => HTMLElements["dir"];
-} & GlobalAriaAttributes<"dir"> & GlobalHTMLAttributes<"dir">;
+  compact: (value: string) => HTMLElements["dir"];
+} & GlobalAriaAttributes<"dir"> &
+  GlobalHTMLAttributes<"dir">;
 
 type divElement = {
-  "role": (value: string) => HTMLElements["div"];
-} & GlobalAriaAttributes<"div"> & GlobalHTMLAttributes<"div">;
+  role: (value: string) => HTMLElements["div"];
+} & GlobalAriaAttributes<"div"> &
+  GlobalHTMLAttributes<"div">;
 
 type dlElement = {
-  "role": (value: string) => HTMLElements["dl"];
-} & GlobalAriaAttributes<"dl"> & GlobalHTMLAttributes<"dl">;
+  role: (value: string) => HTMLElements["dl"];
+} & GlobalAriaAttributes<"dl"> &
+  GlobalHTMLAttributes<"dl">;
 
 type dtElement = {
-  "role": (value: string) => HTMLElements["dt"];
-} & GlobalAriaAttributes<"dt"> & GlobalHTMLAttributes<"dt">;
+  role: (value: string) => HTMLElements["dt"];
+} & GlobalAriaAttributes<"dt"> &
+  GlobalHTMLAttributes<"dt">;
 
 type emElement = {
-  "role": (value: string) => HTMLElements["em"];
-} & GlobalAriaAttributes<"em"> & GlobalHTMLAttributes<"em">;
+  role: (value: string) => HTMLElements["em"];
+} & GlobalAriaAttributes<"em"> &
+  GlobalHTMLAttributes<"em">;
 
 type embedElement = {
   /** The displayed height of the resource, in CSS pixels. This must be an absolute value; percentages are not allowed. */
-  "height": (value: number) => HTMLElements["embed"];
-  "role": (value: string) => HTMLElements["embed"];
-  "src": (value: string) => HTMLElements["embed"];
-  "type": (value: string) => HTMLElements["embed"];
+  height: (value: number) => HTMLElements["embed"];
+  role: (value: string) => HTMLElements["embed"];
+  src: (value: string) => HTMLElements["embed"];
+  type: (value: string) => HTMLElements["embed"];
   /** The displayed width of the resource, in CSS pixels. This must be an absolute value; percentages are not allowed. */
-  "width": (value: number) => HTMLElements["embed"];
-} & GlobalAriaAttributes<"embed"> & GlobalHTMLAttributes<"embed">;
+  width: (value: number) => HTMLElements["embed"];
+} & GlobalAriaAttributes<"embed"> &
+  GlobalHTMLAttributes<"embed">;
 
 type fieldsetElement = {
   /** If this Boolean attribute is set, all form controls that are descendants of the <fieldset>, are disabled, meaning they are not editable and won't be submitted along with the <form>. They won't receive any browsing events, like mouse clicks or focus-related events. By default browsers display such controls grayed out. Note that form elements inside the <legend> element won't be disabled. */
-  "disabled": (value: boolean) => HTMLElements["fieldset"];
+  disabled: (value: boolean) => HTMLElements["fieldset"];
   /** This attribute takes the value of the id attribute of a <form> element you want the <fieldset> to be part of, even if it is not inside the form. Please note that usage of this is confusing — if you want the <input> elements inside the <fieldset> to be associated with the form, you need to use the form attribute directly on those elements. You can check which elements are associated with a form via JavaScript, using HTMLFormElement.elements. */
-  "form": (value: string) => HTMLElements["fieldset"];
+  form: (value: string) => HTMLElements["fieldset"];
   /** The name associated with the group. Note: The caption for the fieldset is given by the first <legend> element nested inside it. */
-  "name": (value: string) => HTMLElements["fieldset"];
-  "role": (value: string) => HTMLElements["fieldset"];
-} & GlobalAriaAttributes<"fieldset"> & GlobalHTMLAttributes<"fieldset">;
+  name: (value: string) => HTMLElements["fieldset"];
+  role: (value: string) => HTMLElements["fieldset"];
+} & GlobalAriaAttributes<"fieldset"> &
+  GlobalHTMLAttributes<"fieldset">;
 
 type figcaptionElement = {
-  "role": (value: string) => HTMLElements["figcaption"];
-} & GlobalAriaAttributes<"figcaption"> & GlobalHTMLAttributes<"figcaption">;
+  role: (value: string) => HTMLElements["figcaption"];
+} & GlobalAriaAttributes<"figcaption"> &
+  GlobalHTMLAttributes<"figcaption">;
 
 type figureElement = {
-  "role": (value: string) => HTMLElements["figure"];
-} & GlobalAriaAttributes<"figure"> & GlobalHTMLAttributes<"figure">;
+  role: (value: string) => HTMLElements["figure"];
+} & GlobalAriaAttributes<"figure"> &
+  GlobalHTMLAttributes<"figure">;
 
 type fontElement = {
   /** This attribute sets the text color using either a named color or a color specified in the hexadecimal #RRGGBB format. */
-  "color": (value: string) => HTMLElements["font"];
+  color: (value: string) => HTMLElements["font"];
   /** This attribute contains a comma-separated list of one or more font names. The document text in the default style is rendered in the first font face that the client's browser supports. If no font listed is installed on the local system, the browser typically defaults to the proportional or fixed-width font for that system. */
-  "face": (value: string) => HTMLElements["font"];
+  face: (value: string) => HTMLElements["font"];
   /** This attribute specifies the font size as either a numeric or relative value. Numeric values range from 1 to 7 with 1 being the smallest and 3 the default. It can be defined using a relative value, like +2 or -3, which set it relative to the value of the size attribute of the <basefont> element, or relative to 3, the default value, if none does exist. */
-  "size": (value: string) => HTMLElements["font"];
-} & GlobalAriaAttributes<"font"> & GlobalHTMLAttributes<"font">;
+  size: (value: string) => HTMLElements["font"];
+} & GlobalAriaAttributes<"font"> &
+  GlobalHTMLAttributes<"font">;
 
 type footerElement = {
-  "role": (value: string) => HTMLElements["footer"];
-} & GlobalAriaAttributes<"footer"> & GlobalHTMLAttributes<"footer">;
+  role: (value: string) => HTMLElements["footer"];
+} & GlobalAriaAttributes<"footer"> &
+  GlobalHTMLAttributes<"footer">;
 
 type formElement = {
   /** @deprecated Comma-separated content types the server accepts. Note: This attribute was removed in HTML5 and should not be used. Instead, use the accept attribute on <input type=file> elements. */
-  "accept": (value: string) => HTMLElements["form"];
-  "acceptCharset": (value: "utf-8") => HTMLElements["form"];
-  "action": (value: string) => HTMLElements["form"];
-  "autocomplete": (value: "on" | "off") => HTMLElements["form"];
-  "enctype": (value: "application/x-www-form-urlencoded" | "multipart/form-data" | "text/plain") => HTMLElements["form"];
-  "method": (value: "post" | "get" | "dialog") => HTMLElements["form"];
-  "name": (value: string) => HTMLElements["form"];
-  "novalidate": (value: boolean) => HTMLElements["form"];
-  "rel": (value: string) => HTMLElements["form"];
-  "role": (value: string) => HTMLElements["form"];
-  "target": (value: string) => HTMLElements["form"];
-} & GlobalAriaAttributes<"form"> & GlobalHTMLAttributes<"form">;
+  accept: (value: string) => HTMLElements["form"];
+  acceptCharset: (value: "utf-8") => HTMLElements["form"];
+  action: (value: string) => HTMLElements["form"];
+  autocomplete: (value: "on" | "off") => HTMLElements["form"];
+  enctype: (
+    value:
+      | "application/x-www-form-urlencoded"
+      | "multipart/form-data"
+      | "text/plain"
+  ) => HTMLElements["form"];
+  method: (value: "post" | "get" | "dialog") => HTMLElements["form"];
+  name: (value: string) => HTMLElements["form"];
+  novalidate: (value: boolean) => HTMLElements["form"];
+  rel: (value: string) => HTMLElements["form"];
+  role: (value: string) => HTMLElements["form"];
+  target: (value: string) => HTMLElements["form"];
+} & GlobalAriaAttributes<"form"> &
+  GlobalHTMLAttributes<"form">;
 
 type frameElement = {
   /** This attribute allows you to specify a frame's border. */
-  "frameborder": (value: string) => HTMLElements["frame"];
+  frameborder: (value: string) => HTMLElements["frame"];
   /** This attribute defines the height of the margin between frames. */
-  "marginheight": (value: string) => HTMLElements["frame"];
+  marginheight: (value: string) => HTMLElements["frame"];
   /** This attribute defines the width of the margin between frames. */
-  "marginwidth": (value: string) => HTMLElements["frame"];
+  marginwidth: (value: string) => HTMLElements["frame"];
   /** This attribute is used for labeling frames. Without labeling, every link will open in the frame that it's in – the closest parent frame. See the target attribute for more information. */
-  "name": (value: string) => HTMLElements["frame"];
+  name: (value: string) => HTMLElements["frame"];
   /** This attribute prevents resizing of frames by users. */
-  "noresize": (value: string) => HTMLElements["frame"];
+  noresize: (value: string) => HTMLElements["frame"];
   /** This attribute defines the existence of a scrollbar. If this attribute is not used, the browser adds a scrollbar when necessary. There are two choices: "yes" for forcing a scrollbar even when it is not necessary and "no" for forcing no scrollbar even when it is necessary. */
-  "scrolling": (value: string) => HTMLElements["frame"];
+  scrolling: (value: string) => HTMLElements["frame"];
   /** This attribute specifies the document that will be displayed by the frame. */
-  "src": (value: string) => HTMLElements["frame"];
-} & GlobalAriaAttributes<"frame"> & GlobalHTMLAttributes<"frame">;
+  src: (value: string) => HTMLElements["frame"];
+} & GlobalAriaAttributes<"frame"> &
+  GlobalHTMLAttributes<"frame">;
 
 type framesetElement = {
   /** This attribute specifies the number and size of horizontal spaces in a frameset. */
-  "cols": (value: string) => HTMLElements["frameset"];
+  cols: (value: string) => HTMLElements["frameset"];
   /** This attribute specifies the number and size of vertical spaces in a frameset. */
-  "rows": (value: string) => HTMLElements["frameset"];
-} & GlobalAriaAttributes<"frameset"> & GlobalHTMLAttributes<"frameset">;
+  rows: (value: string) => HTMLElements["frameset"];
+} & GlobalAriaAttributes<"frameset"> &
+  GlobalHTMLAttributes<"frameset">;
 
 type h1Element = {
-  "role": (value: string) => HTMLElements["h1"];
-} & GlobalAriaAttributes<"h1"> & GlobalHTMLAttributes<"h1">;
+  role: (value: string) => HTMLElements["h1"];
+} & GlobalAriaAttributes<"h1"> &
+  GlobalHTMLAttributes<"h1">;
 
 type h2Element = {
-  "role": (value: string) => HTMLElements["h2"];
-} & GlobalAriaAttributes<"h2"> & GlobalHTMLAttributes<"h2">;
+  role: (value: string) => HTMLElements["h2"];
+} & GlobalAriaAttributes<"h2"> &
+  GlobalHTMLAttributes<"h2">;
 
 type h3Element = {
-  "role": (value: string) => HTMLElements["h3"];
-} & GlobalAriaAttributes<"h3"> & GlobalHTMLAttributes<"h3">;
+  role: (value: string) => HTMLElements["h3"];
+} & GlobalAriaAttributes<"h3"> &
+  GlobalHTMLAttributes<"h3">;
 
 type h4Element = {
-  "role": (value: string) => HTMLElements["h4"];
-} & GlobalAriaAttributes<"h4"> & GlobalHTMLAttributes<"h4">;
+  role: (value: string) => HTMLElements["h4"];
+} & GlobalAriaAttributes<"h4"> &
+  GlobalHTMLAttributes<"h4">;
 
 type h5Element = {
-  "role": (value: string) => HTMLElements["h5"];
-} & GlobalAriaAttributes<"h5"> & GlobalHTMLAttributes<"h5">;
+  role: (value: string) => HTMLElements["h5"];
+} & GlobalAriaAttributes<"h5"> &
+  GlobalHTMLAttributes<"h5">;
 
 type headElement = {
   /** @deprecated The URIs of one or more metadata profiles, separated by white space. */
-  "profile": (value: string) => HTMLElements["head"];
-  "role": (value: string) => HTMLElements["head"];
-} & GlobalAriaAttributes<"head"> & GlobalHTMLAttributes<"head">;
+  profile: (value: string) => HTMLElements["head"];
+  role: (value: string) => HTMLElements["head"];
+} & GlobalAriaAttributes<"head"> &
+  GlobalHTMLAttributes<"head">;
 
 type headerElement = {
-  "role": (value: string) => HTMLElements["header"];
-} & GlobalAriaAttributes<"header"> & GlobalHTMLAttributes<"header">;
+  role: (value: string) => HTMLElements["header"];
+} & GlobalAriaAttributes<"header"> &
+  GlobalHTMLAttributes<"header">;
 
 type hgroupElement = {
-  "role": (value: string) => HTMLElements["hgroup"];
-} & GlobalAriaAttributes<"hgroup"> & GlobalHTMLAttributes<"hgroup">;
+  role: (value: string) => HTMLElements["hgroup"];
+} & GlobalAriaAttributes<"hgroup"> &
+  GlobalHTMLAttributes<"hgroup">;
 
 type hrElement = {
   /** @deprecated Sets the alignment of the rule on the page. If no value is specified, the default value is left. */
-  "align": (value: string) => HTMLElements["hr"];
+  align: (value: string) => HTMLElements["hr"];
   /** Sets the color of the rule through color name or hexadecimal value. */
-  "color": (value: string) => HTMLElements["hr"];
+  color: (value: string) => HTMLElements["hr"];
   /** @deprecated Sets the rule to have no shading. */
-  "noshade": (value: string) => HTMLElements["hr"];
-  "role": (value: string) => HTMLElements["hr"];
+  noshade: (value: string) => HTMLElements["hr"];
+  role: (value: string) => HTMLElements["hr"];
   /** @deprecated Sets the height, in pixels, of the rule. */
-  "size": (value: string) => HTMLElements["hr"];
+  size: (value: string) => HTMLElements["hr"];
   /** @deprecated Sets the length of the rule on the page through a pixel or percentage value. */
-  "width": (value: string) => HTMLElements["hr"];
-} & GlobalAriaAttributes<"hr"> & GlobalHTMLAttributes<"hr">;
+  width: (value: string) => HTMLElements["hr"];
+} & GlobalAriaAttributes<"hr"> &
+  GlobalHTMLAttributes<"hr">;
 
 type htmlElement = {
   /** @deprecated Specifies the URI of a resource manifest indicating resources that should be cached locally. */
-  "manifest": (value: string) => HTMLElements["html"];
-  "role": (value: string) => HTMLElements["html"];
+  manifest: (value: string) => HTMLElements["html"];
+  role: (value: string) => HTMLElements["html"];
   /** @deprecated Specifies the version of the HTML Document Type Definition that governs the current document. This attribute is not needed, because it is redundant with the version information in the document type declaration. */
-  "version": (value: string) => HTMLElements["html"];
-} & GlobalAriaAttributes<"html"> & GlobalHTMLAttributes<"html">;
+  version: (value: string) => HTMLElements["html"];
+} & GlobalAriaAttributes<"html"> &
+  GlobalHTMLAttributes<"html">;
 
 type iElement = {
-  "role": (value: string) => HTMLElements["i"];
-} & GlobalAriaAttributes<"i"> & GlobalHTMLAttributes<"i">;
+  role: (value: string) => HTMLElements["i"];
+} & GlobalAriaAttributes<"i"> &
+  GlobalHTMLAttributes<"i">;
 
 type iframeElement = {
   /** @deprecated The alignment of this element with respect to the surrounding context. */
-  "align": (value: string) => HTMLElements["iframe"];
-  "allow": (value: string) => HTMLElements["iframe"];
-  "allowfullscreen": (value: boolean) => HTMLElements["iframe"];
+  align: (value: string) => HTMLElements["iframe"];
+  allow: (value: string) => HTMLElements["iframe"];
+  allowfullscreen: (value: boolean) => HTMLElements["iframe"];
   /** Set to true if a cross-origin <iframe> should be allowed to invoke the Payment Request API. Note: This attribute is considered a legacy attribute and redefined as allow="payment". */
-  "allowpaymentrequest": (value: string) => HTMLElements["iframe"];
+  allowpaymentrequest: (value: string) => HTMLElements["iframe"];
   /** A Content Security Policy enforced for the embedded resource. See HTMLIFrameElement.csp for details. */
-  "csp": (value: string) => HTMLElements["iframe"];
+  csp: (value: string) => HTMLElements["iframe"];
   /** @deprecated The value 1 (the default) draws a border around this frame. The value 0 removes the border around this frame, but you should instead use the CSS property border to control <iframe> borders. */
-  "frameborder": (value: string) => HTMLElements["iframe"];
+  frameborder: (value: string) => HTMLElements["iframe"];
   /** The height of the frame in CSS pixels. Default is 150. */
-  "height": (value: number) => HTMLElements["iframe"];
+  height: (value: number) => HTMLElements["iframe"];
   /** Indicates how the browser should load the iframe: eager: Load the iframe immediately, regardless if it is outside the visible viewport (this is the default value). lazy: Defer loading of the iframe until it reaches a calculated distance from the viewport, as defined by the browser. */
-  "loading": (value: "lazy" | "eager") => HTMLElements["iframe"];
+  loading: (value: "lazy" | "eager") => HTMLElements["iframe"];
   /** @deprecated A URL of a long description of the frame's content. Due to widespread misuse, this is not helpful for non-visual browsers. */
-  "longdesc": (value: string) => HTMLElements["iframe"];
+  longdesc: (value: string) => HTMLElements["iframe"];
   /** @deprecated The amount of space in pixels between the frame's content and its top and bottom borders. */
-  "marginheight": (value: string) => HTMLElements["iframe"];
+  marginheight: (value: string) => HTMLElements["iframe"];
   /** @deprecated The amount of space in pixels between the frame's content and its left and right borders. */
-  "marginwidth": (value: string) => HTMLElements["iframe"];
-  "name": (value: string) => HTMLElements["iframe"];
+  marginwidth: (value: string) => HTMLElements["iframe"];
+  name: (value: string) => HTMLElements["iframe"];
   /** Indicates which referrer to send when fetching the frame's resource: no-referrer: The Referer header will not be sent. no-referrer-when-downgrade: The Referer header will not be sent to origins without TLS (HTTPS). origin: The sent referrer will be limited to the origin of the referring page: its scheme, host, and port. origin-when-cross-origin: The referrer sent to other origins will be limited to the scheme, the host, and the port. Navigations on the same origin will still include the path. same-origin: A referrer will be sent for same origin, but cross-origin requests will contain no referrer information. strict-origin: Only send the origin of the document as the referrer when the protocol security level stays the same (HTTPS→HTTPS), but don't send it to a less secure destination (HTTPS→HTTP). strict-origin-when-cross-origin (default): Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP). unsafe-url: The referrer will include the origin and the path (but not the fragment, password, or username). This value is unsafe, because it leaks origins and paths from TLS-protected resources to insecure origins. */
-  "referrerpolicy": (value: "" | "no-referrer" | "no-referrer-when-downgrade" | "same-origin" | "origin" | "strict-origin" | "origin-when-cross-origin" | "strict-origin-when-cross-origin" | "unsafe-url") => HTMLElements["iframe"];
-  "role": (value: string) => HTMLElements["iframe"];
-  "sandbox": (value: string) => HTMLElements["iframe"];
+  referrerpolicy: (
+    value:
+      | ""
+      | "no-referrer"
+      | "no-referrer-when-downgrade"
+      | "same-origin"
+      | "origin"
+      | "strict-origin"
+      | "origin-when-cross-origin"
+      | "strict-origin-when-cross-origin"
+      | "unsafe-url"
+  ) => HTMLElements["iframe"];
+  role: (value: string) => HTMLElements["iframe"];
+  sandbox: (value: string) => HTMLElements["iframe"];
   /** @deprecated Indicates when the browser should provide a scrollbar for the frame: auto: Only when the frame's content is larger than its dimensions. yes: Always show a scrollbar. no: Never show a scrollbar. */
-  "scrolling": (value: string) => HTMLElements["iframe"];
-  "src": (value: string) => HTMLElements["iframe"];
-  "srcdoc": (value: string) => HTMLElements["iframe"];
+  scrolling: (value: string) => HTMLElements["iframe"];
+  src: (value: string) => HTMLElements["iframe"];
+  srcdoc: (value: string) => HTMLElements["iframe"];
   /** The width of the frame in CSS pixels. Default is 300. */
-  "width": (value: number) => HTMLElements["iframe"];
-} & GlobalAriaAttributes<"iframe"> & GlobalHTMLAttributes<"iframe">;
+  width: (value: number) => HTMLElements["iframe"];
+} & GlobalAriaAttributes<"iframe"> &
+  GlobalHTMLAttributes<"iframe">;
 
-type imageElement = {
-} & GlobalAriaAttributes<"image"> & GlobalHTMLAttributes<"image">;
+type imageElement = {} & GlobalAriaAttributes<"image"> &
+  GlobalHTMLAttributes<"image">;
 
 type imgElement = {
   /** @deprecated Aligns the image with its surrounding context. Use the float and/or vertical-align CSS properties instead of this attribute. Allowed values: top Equivalent to vertical-align: top or vertical-align: text-top middle Equivalent to vertical-align: -moz-middle-with-baseline bottom The default, equivalent to vertical-align: unset or vertical-align: initial left Equivalent to float: left right Equivalent to float: right */
-  "align": (value: string) => HTMLElements["img"];
-  "alt": (value: string) => HTMLElements["img"];
+  align: (value: string) => HTMLElements["img"];
+  alt: (value: string) => HTMLElements["img"];
   /** @deprecated The width of a border around the image. Use the border CSS property instead. */
-  "border": (value: string) => HTMLElements["img"];
+  border: (value: string) => HTMLElements["img"];
   /** Indicates if the fetching of the image must be done using a CORS request. Image data from a CORS-enabled image returned from a CORS request can be reused in the <canvas> element without being marked "tainted". If the crossorigin attribute is not specified, then a non-CORS request is sent (without the Origin request header), and the browser marks the image as tainted and restricts access to its image data, preventing its usage in <canvas> elements. If the crossorigin attribute is specified, then a CORS request is sent (with the Origin request header); but if the server does not opt into allowing cross-origin access to the image data by the origin site (by not sending any Access-Control-Allow-Origin response header, or by not including the site's origin in any Access-Control-Allow-Origin response header it does send), then the browser blocks the image from loading, and logs a CORS error to the devtools console. Allowed values: anonymous A CORS request is sent with credentials omitted (that is, no cookies, X.509 certificates, or Authorization request header). use-credentials The CORS request is sent with any credentials included (that is, cookies, X.509 certificates, and the Authorization request header). If the server does not opt into sharing credentials with the origin site (by sending back the Access-Control-Allow-Credentials: true response header), then the browser marks the image as tainted and restricts access to its image data. If the attribute has an invalid value, browsers handle it as if the anonymous value was used. See CORS settings attributes for additional information. */
-  "crossorigin": (value: "" | "anonymous" | "use-credentials") => HTMLElements["img"];
-  "decoding": (value: "sync" | "async" | "auto") => HTMLElements["img"];
+  crossorigin: (
+    value: "" | "anonymous" | "use-credentials"
+  ) => HTMLElements["img"];
+  decoding: (value: "sync" | "async" | "auto") => HTMLElements["img"];
   /** The intrinsic height of the image, in pixels. Must be an integer without a unit. */
-  "height": (value: number) => HTMLElements["img"];
+  height: (value: number) => HTMLElements["img"];
   /** @deprecated The number of pixels of white space on the left and right of the image. Use the margin CSS property instead. */
-  "hspace": (value: string) => HTMLElements["img"];
+  hspace: (value: string) => HTMLElements["img"];
   /** @deprecated This attribute tells the browser to ignore the actual intrinsic size of the image and pretend it's the size specified in the attribute. Specifically, the image would raster at these dimensions and naturalWidth/naturalHeight on images would return the values specified in this attribute. Explainer, examples */
-  "intrinsicsize": (value: string) => HTMLElements["img"];
-  "ismap": (value: boolean) => HTMLElements["img"];
+  intrinsicsize: (value: string) => HTMLElements["img"];
+  ismap: (value: boolean) => HTMLElements["img"];
   /** Indicates how the browser should load the image: eager: Loads the image immediately, regardless of whether or not the image is currently within the visible viewport (this is the default value). lazy: Defers loading the image until it reaches a calculated distance from the viewport, as defined by the browser. The intent is to avoid the network and storage bandwidth needed to handle the image until it's reasonably certain that it will be needed. This generally improves the performance of the content in most typical use cases. Note: Loading is only deferred when JavaScript is enabled. This is an anti-tracking measure, because if a user agent supported lazy loading when scripting is disabled, it would still be possible for a site to track a user's approximate scroll position throughout a session, by strategically placing images in a page's markup such that a server can track how many images are requested and when. */
-  "loading": (value: "lazy" | "eager") => HTMLElements["img"];
+  loading: (value: "lazy" | "eager") => HTMLElements["img"];
   /** @deprecated A link to a more detailed description of the image. Possible values are a URL or an element id. Note: This attribute is mentioned in the latest W3C version, HTML 5.2, but has been removed from the WHATWG's HTML Living Standard. It has an uncertain future; authors should use a WAI-ARIA alternative such as aria-describedby or aria-details. */
-  "longdesc": (value: string) => HTMLElements["img"];
+  longdesc: (value: string) => HTMLElements["img"];
   /** @deprecated A name for the element. Use the id attribute instead. */
-  "name": (value: string) => HTMLElements["img"];
+  name: (value: string) => HTMLElements["img"];
   /** A string indicating which referrer to use when fetching the resource: no-referrer: The Referer header will not be sent. no-referrer-when-downgrade: The Referer header will not be sent to origins without TLS (HTTPS). origin: The sent referrer will be limited to the origin of the referring page: its scheme, host, and port. origin-when-cross-origin: The referrer sent to other origins will be limited to the scheme, the host, and the port. Navigations on the same origin will still include the path. same-origin: A referrer will be sent for same origin, but cross-origin requests will contain no referrer information. strict-origin: Only send the origin of the document as the referrer when the protocol security level stays the same (HTTPS→HTTPS), but don't send it to a less secure destination (HTTPS→HTTP). strict-origin-when-cross-origin (default): Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP). unsafe-url: The referrer will include the origin and the path (but not the fragment, password, or username). This value is unsafe, because it leaks origins and paths from TLS-protected resources to insecure origins. */
-  "referrerpolicy": (value: "" | "no-referrer" | "no-referrer-when-downgrade" | "same-origin" | "origin" | "strict-origin" | "origin-when-cross-origin" | "strict-origin-when-cross-origin" | "unsafe-url") => HTMLElements["img"];
-  "role": (value: string) => HTMLElements["img"];
+  referrerpolicy: (
+    value:
+      | ""
+      | "no-referrer"
+      | "no-referrer-when-downgrade"
+      | "same-origin"
+      | "origin"
+      | "strict-origin"
+      | "origin-when-cross-origin"
+      | "strict-origin-when-cross-origin"
+      | "unsafe-url"
+  ) => HTMLElements["img"];
+  role: (value: string) => HTMLElements["img"];
   /** One or more strings separated by commas, indicating a set of source sizes. Each source size consists of: A media condition. This must be omitted for the last item in the list. A source size value. Media Conditions describe properties of the viewport, not of the image. For example, (max-height: 500px) 1000px proposes to use a source of 1000px width, if the viewport is not higher than 500px. Source size values specify the intended display size of the image. User agents use the current source size to select one of the sources supplied by the srcset attribute, when those sources are described using width (w) descriptors. The selected source size affects the intrinsic size of the image (the image's display size if no CSS styling is applied). If the srcset attribute is absent, or contains no values with a width descriptor, then the sizes attribute has no effect. */
-  "sizes": (value: string) => HTMLElements["img"];
-  "src": (value: string) => HTMLElements["img"];
+  sizes: (value: string) => HTMLElements["img"];
+  src: (value: string) => HTMLElements["img"];
   /** One or more strings separated by commas, indicating possible image sources for the user agent to use. Each string is composed of: A URL to an image Optionally, whitespace followed by one of: A width descriptor (a positive integer directly followed by w). The width descriptor is divided by the source size given in the sizes attribute to calculate the effective pixel density. A pixel density descriptor (a positive floating point number directly followed by x). If no descriptor is specified, the source is assigned the default descriptor of 1x. It is incorrect to mix width descriptors and pixel density descriptors in the same srcset attribute. Duplicate descriptors (for instance, two sources in the same srcset which are both described with 2x) are also invalid. The user agent selects any of the available sources at its discretion. This provides them with significant leeway to tailor their selection based on things like user preferences or bandwidth conditions. See our Responsive images tutorial for an example. */
-  "srcset": (value: string) => HTMLElements["img"];
-  "usemap": (value: string) => HTMLElements["img"];
+  srcset: (value: string) => HTMLElements["img"];
+  usemap: (value: string) => HTMLElements["img"];
   /** @deprecated The number of pixels of white space above and below the image. Use the margin CSS property instead. */
-  "vspace": (value: string) => HTMLElements["img"];
+  vspace: (value: string) => HTMLElements["img"];
   /** The intrinsic width of the image in pixels. Must be an integer without a unit. */
-  "width": (value: number) => HTMLElements["img"];
-} & GlobalAriaAttributes<"img"> & GlobalHTMLAttributes<"img">;
+  width: (value: number) => HTMLElements["img"];
+} & GlobalAriaAttributes<"img"> &
+  GlobalHTMLAttributes<"img">;
 
 type inputElement = {
-  "accept": (value: string) => HTMLElements["input"];
-  "alt": (value: string) => HTMLElements["input"];
-  "autocomplete": (value: string) => HTMLElements["input"];
+  accept: (value: string) => HTMLElements["input"];
+  alt: (value: string) => HTMLElements["input"];
+  autocomplete: (value: string) => HTMLElements["input"];
   /** A Safari extension, the autocorrect attribute is a string which indicates whether or not to activate automatic correction while the user is editing this field. Permitted values are: on Enable automatic correction of typos, as well as processing of text substitutions if any are configured. off Disable automatic correction and text substitutions. */
-  "autocorrect": (value: string) => HTMLElements["input"];
+  autocorrect: (value: string) => HTMLElements["input"];
   /** Introduced in the HTML Media Capture specification and valid for the file input type only, the capture attribute defines which media—microphone, video, or camera—should be used to capture a new file for upload with file upload control in supporting scenarios. See the file input type. */
-  "capture": (value: string) => HTMLElements["input"];
-  "checked": (value: boolean) => HTMLElements["input"];
-  "dirname": (value: string) => HTMLElements["input"];
+  capture: (value: string) => HTMLElements["input"];
+  checked: (value: boolean) => HTMLElements["input"];
+  dirname: (value: string) => HTMLElements["input"];
   /** A Boolean attribute which, if present, indicates that the user should not be able to interact with the input. Disabled inputs are typically rendered with a dimmer color or using some other form of indication that the field is not available for use. Specifically, disabled inputs do not receive the click event, and disabled inputs are not submitted with the form. Note: Although not required by the specification, Firefox will by default persist the dynamic disabled state of an <input> across page loads. Use the autocomplete attribute to control this feature. */
-  "disabled": (value: boolean) => HTMLElements["input"];
+  disabled: (value: boolean) => HTMLElements["input"];
   /** A string specifying the <form> element with which the input is associated (that is, its form owner). This string's value, if present, must match the id of a <form> element in the same document. If this attribute isn't specified, the <input> element is associated with the nearest containing form, if any. The form attribute lets you place an input anywhere in the document but have it included with a form elsewhere in the document. Note: An input can only be associated with one form. */
-  "form": (value: string) => HTMLElements["input"];
+  form: (value: string) => HTMLElements["input"];
   /** Valid for the image and submit input types only. See the submit input type for more information. */
-  "formaction": (value: string) => HTMLElements["input"];
+  formaction: (value: string) => HTMLElements["input"];
   /** Valid for the image and submit input types only. See the submit input type for more information. */
-  "formenctype": (value: "application/x-www-form-urlencoded" | "multipart/form-data" | "text/plain") => HTMLElements["input"];
+  formenctype: (
+    value:
+      | "application/x-www-form-urlencoded"
+      | "multipart/form-data"
+      | "text/plain"
+  ) => HTMLElements["input"];
   /** Valid for the image and submit input types only. See the submit input type for more information. */
-  "formmethod": (value: "post" | "get" | "dialog") => HTMLElements["input"];
+  formmethod: (value: "post" | "get" | "dialog") => HTMLElements["input"];
   /** Valid for the image and submit input types only. See the submit input type for more information. */
-  "formnovalidate": (value: boolean) => HTMLElements["input"];
+  formnovalidate: (value: boolean) => HTMLElements["input"];
   /** Valid for the image and submit input types only. See the submit input type for more information. */
-  "formtarget": (value: string) => HTMLElements["input"];
-  "height": (value: number) => HTMLElements["input"];
+  formtarget: (value: string) => HTMLElements["input"];
+  height: (value: number) => HTMLElements["input"];
   /** The Boolean attribute incremental is a WebKit and Blink extension (so supported by Safari, Opera, Chrome, etc.) which, if present, tells the user agent to process the input as a live search. As the user edits the value of the field, the user agent sends search events to the HTMLInputElement object representing the search box. This allows your code to update the search results in real time as the user edits the search. If incremental is not specified, the search event is only sent when the user explicitly initiates a search (such as by pressing the Enter or Return key while editing the field). The search event is rate-limited so that it is not sent more frequently than an implementation-defined interval. */
-  "incremental": (value: string) => HTMLElements["input"];
-  "list": (value: string) => HTMLElements["input"];
-  "max": (value: string) => HTMLElements["input"];
-  "maxlength": (value: number) => HTMLElements["input"];
-  "min": (value: string) => HTMLElements["input"];
-  "minlength": (value: number) => HTMLElements["input"];
+  incremental: (value: string) => HTMLElements["input"];
+  list: (value: string) => HTMLElements["input"];
+  max: (value: string) => HTMLElements["input"];
+  maxlength: (value: number) => HTMLElements["input"];
+  min: (value: string) => HTMLElements["input"];
+  minlength: (value: number) => HTMLElements["input"];
   /** A Mozilla extension, supported by Firefox for Android, which provides a hint as to what sort of action will be taken if the user presses the Enter or Return key while editing the field. This information is used to decide what kind of label to use on the Enter key on the virtual keyboard. Note: This has been standardized as the global attribute enterkeyhint, but is not yet widely implemented. To see the status of the change being implemented in Firefox, see bug 1490661. Permitted values are: go, done, next, search, and send. The browser decides, using this hint, what label to put on the enter key. */
-  "mozactionhint": (value: string) => HTMLElements["input"];
-  "multiple": (value: boolean) => HTMLElements["input"];
+  mozactionhint: (value: string) => HTMLElements["input"];
+  multiple: (value: boolean) => HTMLElements["input"];
   /** A string specifying a name for the input control. This name is submitted along with the control's value when the form data is submitted. Consider the name a required attribute (even though it's not). If an input has no name specified, or name is empty, the input's value is not submitted with the form! (Disabled controls, unchecked radio buttons, unchecked checkboxes, and reset buttons are also not sent.) There are two special cases: _charset_ : If used as the name of an <input> element of type hidden, the input's value is automatically set by the user agent to the character encoding being used to submit the form. isindex: For historical reasons, the name isindex is not allowed. The name attribute creates a unique behavior for radio buttons. Only one radio button in a same-named group of radio buttons can be checked at a time. Selecting any radio button in that group automatically deselects any currently-selected radio button in the same group. The value of that one checked radio button is sent along with the name if the form is submitted, When tabbing into a series of same-named group of radio buttons, if one is checked, that one will receive focus. If they aren't grouped together in source order, if one of the group is checked, tabbing into the group starts when the first one in the group is encountered, skipping all those that aren't checked. In other words, if one is checked, tabbing skips the unchecked radio buttons in the group. If none are checked, the radio button group receives focus when the first button in the same name group is reached. Once one of the radio buttons in a group has focus, using the arrow keys will navigate through all the radio buttons of the same name, even if the radio buttons are not grouped together in the source order. When an input element is given a name, that name becomes a property of the owning form element's HTMLFormElement.elements property. If you have an input whose name is set to guest and another whose name is hat-size, the following code can be used: let form = document.querySelector("form"); let guestName = form.elements.guest; let hatSize = form.elements["hat-size"]; When this code has run, guestName will be the HTMLInputElement for the guest field, and hatSize the object for the hat-size field. Warning: Avoid giving form elements a name that corresponds to a built-in property of the form, since you would then override the predefined property or method with this reference to the corresponding input. */
-  "name": (value: string) => HTMLElements["input"];
+  name: (value: string) => HTMLElements["input"];
   /** Similar to the -moz-orient non-standard CSS property impacting the <progress> and <meter> elements, the orient attribute defines the orientation of the range slider. Values include horizontal, meaning the range is rendered horizontally, and vertical, where the range is rendered vertically. */
-  "orient": (value: string) => HTMLElements["input"];
-  "pattern": (value: string) => HTMLElements["input"];
-  "placeholder": (value: string) => HTMLElements["input"];
-  "readonly": (value: boolean) => HTMLElements["input"];
-  "required": (value: boolean) => HTMLElements["input"];
+  orient: (value: string) => HTMLElements["input"];
+  pattern: (value: string) => HTMLElements["input"];
+  placeholder: (value: string) => HTMLElements["input"];
+  readonly: (value: boolean) => HTMLElements["input"];
+  required: (value: boolean) => HTMLElements["input"];
   /** The results attribute—supported only by Safari—is a numeric value that lets you override the maximum number of entries to be displayed in the <input> element's natively-provided drop-down menu of previous search queries. The value must be a non-negative decimal number. If not provided, or an invalid value is given, the browser's default maximum number of entries is used. */
-  "results": (value: string) => HTMLElements["input"];
-  "role": (value: string) => HTMLElements["input"];
-  "size": (value: string) => HTMLElements["input"];
-  "src": (value: string) => HTMLElements["input"];
-  "step": (value: string) => HTMLElements["input"];
-  "type": (value: "hidden" | "text" | "search" | "tel" | "url" | "email" | "password" | "date" | "month" | "week" | "time" | "datetime-local" | "number" | "range" | "color" | "checkbox" | "radio" | "file" | "submit" | "image" | "reset" | "button") => HTMLElements["input"];
-  "value": (value: string) => HTMLElements["input"];
+  results: (value: string) => HTMLElements["input"];
+  role: (value: string) => HTMLElements["input"];
+  size: (value: string) => HTMLElements["input"];
+  src: (value: string) => HTMLElements["input"];
+  step: (value: string) => HTMLElements["input"];
+  type: (
+    value:
+      | "hidden"
+      | "text"
+      | "search"
+      | "tel"
+      | "url"
+      | "email"
+      | "password"
+      | "date"
+      | "month"
+      | "week"
+      | "time"
+      | "datetime-local"
+      | "number"
+      | "range"
+      | "color"
+      | "checkbox"
+      | "radio"
+      | "file"
+      | "submit"
+      | "image"
+      | "reset"
+      | "button"
+  ) => HTMLElements["input"];
+  value: (value: string) => HTMLElements["input"];
   /** The Boolean webkitdirectory attribute, if present, indicates that only directories should be available to be selected by the user in the file picker interface. See HTMLInputElement.webkitdirectory for additional details and examples. Though originally implemented only for WebKit-based browsers, webkitdirectory is also usable in Microsoft Edge as well as Firefox 50 and later. However, even though it has relatively broad support, it is still not standard and should not be used unless you have no alternative. */
-  "webkitdirectory": (value: string) => HTMLElements["input"];
-  "width": (value: number) => HTMLElements["input"];
-} & GlobalAriaAttributes<"input"> & GlobalHTMLAttributes<"input">;
+  webkitdirectory: (value: string) => HTMLElements["input"];
+  width: (value: number) => HTMLElements["input"];
+} & GlobalAriaAttributes<"input"> &
+  GlobalHTMLAttributes<"input">;
 
 type insElement = {
-  "cite": (value: string) => HTMLElements["ins"];
-  "datetime": (value: string) => HTMLElements["ins"];
-  "role": (value: string) => HTMLElements["ins"];
-} & GlobalAriaAttributes<"ins"> & GlobalHTMLAttributes<"ins">;
+  cite: (value: string) => HTMLElements["ins"];
+  datetime: (value: string) => HTMLElements["ins"];
+  role: (value: string) => HTMLElements["ins"];
+} & GlobalAriaAttributes<"ins"> &
+  GlobalHTMLAttributes<"ins">;
 
-type isindexElement = {
-} & GlobalAriaAttributes<"isindex"> & GlobalHTMLAttributes<"isindex">;
+type isindexElement = {} & GlobalAriaAttributes<"isindex"> &
+  GlobalHTMLAttributes<"isindex">;
 
 type kbdElement = {
-  "role": (value: string) => HTMLElements["kbd"];
-} & GlobalAriaAttributes<"kbd"> & GlobalHTMLAttributes<"kbd">;
+  role: (value: string) => HTMLElements["kbd"];
+} & GlobalAriaAttributes<"kbd"> &
+  GlobalHTMLAttributes<"kbd">;
 
 type keygenElement = {
   /** A challenge string that is submitted along with the public key. Defaults to an empty string if not specified. */
-  "challenge": (value: string) => HTMLElements["keygen"];
+  challenge: (value: string) => HTMLElements["keygen"];
   /** This Boolean attribute indicates that the form control is not available for interaction. */
-  "disabled": (value: string) => HTMLElements["keygen"];
+  disabled: (value: string) => HTMLElements["keygen"];
   /** The form element that this element is associated with (its form owner). The value of the attribute must be an id of a <form> element in the same document. If this attribute is not specified, this element must be a descendant of a <form> element. This attribute enables you to place <keygen> elements anywhere within a document, not just as descendants of their form elements. */
-  "form": (value: string) => HTMLElements["keygen"];
+  form: (value: string) => HTMLElements["keygen"];
   /** The type of key generated. The default value is RSA. */
-  "keytype": (value: string) => HTMLElements["keygen"];
+  keytype: (value: string) => HTMLElements["keygen"];
   /** The name of the control, which is submitted with the form data. */
-  "name": (value: string) => HTMLElements["keygen"];
-} & GlobalAriaAttributes<"keygen"> & GlobalHTMLAttributes<"keygen">;
+  name: (value: string) => HTMLElements["keygen"];
+} & GlobalAriaAttributes<"keygen"> &
+  GlobalHTMLAttributes<"keygen">;
 
 type labelElement = {
-  "for": (value: string) => HTMLElements["label"];
-  "role": (value: string) => HTMLElements["label"];
-} & GlobalAriaAttributes<"label"> & GlobalHTMLAttributes<"label">;
+  for: (value: string) => HTMLElements["label"];
+  role: (value: string) => HTMLElements["label"];
+} & GlobalAriaAttributes<"label"> &
+  GlobalHTMLAttributes<"label">;
 
 type legendElement = {
-  "role": (value: string) => HTMLElements["legend"];
-} & GlobalAriaAttributes<"legend"> & GlobalHTMLAttributes<"legend">;
+  role: (value: string) => HTMLElements["legend"];
+} & GlobalAriaAttributes<"legend"> &
+  GlobalHTMLAttributes<"legend">;
 
 type liElement = {
-  "role": (value: string) => HTMLElements["li"];
+  role: (value: string) => HTMLElements["li"];
   /** @deprecated This character attribute indicates the numbering type: a: lowercase letters A: uppercase letters i: lowercase Roman numerals I: uppercase Roman numerals 1: numbers This type overrides the one used by its parent <ol> element, if any. Note: This attribute has been deprecated; use the CSS list-style-type property instead. */
-  "type": (value: string) => HTMLElements["li"];
-  "value": (value: string) => HTMLElements["li"];
-} & GlobalAriaAttributes<"li"> & GlobalHTMLAttributes<"li">;
+  type: (value: string) => HTMLElements["li"];
+  value: (value: string) => HTMLElements["li"];
+} & GlobalAriaAttributes<"li"> &
+  GlobalHTMLAttributes<"li">;
 
 type linkElement = {
-  "as": (value: "fetch" | "audio" | "audioworklet" | "document" | "embed" | "font" | "frame" | "iframe" | "image" | "manifest" | "object" | "paintworklet" | "report" | "script" | "serviceworker" | "sharedworker" | "style" | "track" | "video" | "worker" | "xslt") => HTMLElements["link"];
-  "blocking": (value: "render") => HTMLElements["link"];
+  as: (
+    value:
+      | "fetch"
+      | "audio"
+      | "audioworklet"
+      | "document"
+      | "embed"
+      | "font"
+      | "frame"
+      | "iframe"
+      | "image"
+      | "manifest"
+      | "object"
+      | "paintworklet"
+      | "report"
+      | "script"
+      | "serviceworker"
+      | "sharedworker"
+      | "style"
+      | "track"
+      | "video"
+      | "worker"
+      | "xslt"
+  ) => HTMLElements["link"];
+  blocking: (value: "render") => HTMLElements["link"];
   /** @deprecated This attribute defines the character encoding of the linked resource. The value is a space- and/or comma-delimited list of character sets as defined in RFC 2045. The default value is iso-8859-1. Note: To produce the same effect as this obsolete attribute, use the Content-Type HTTP header on the linked resource. */
-  "charset": (value: string) => HTMLElements["link"];
-  "color": (value: string) => HTMLElements["link"];
+  charset: (value: string) => HTMLElements["link"];
+  color: (value: string) => HTMLElements["link"];
   /** This enumerated attribute indicates whether CORS must be used when fetching the resource. CORS-enabled images can be reused in the <canvas> element without being tainted. The allowed values are: anonymous A cross-origin request (i.e. with an Origin HTTP header) is performed, but no credential is sent (i.e. no cookie, X.509 certificate, or HTTP Basic authentication). If the server does not give credentials to the origin site (by not setting the Access-Control-Allow-Origin HTTP header) the resource will be tainted and its usage restricted. use-credentials A cross-origin request (i.e. with an Origin HTTP header) is performed along with a credential sent (i.e. a cookie, certificate, and/or HTTP Basic authentication is performed). If the server does not give credentials to the origin site (through Access-Control-Allow-Credentials HTTP header), the resource will be tainted and its usage restricted. If the attribute is not present, the resource is fetched without a CORS request (i.e. without sending the Origin HTTP header), preventing its non-tainted usage. If invalid, it is handled as if the enumerated keyword anonymous was used. See CORS settings attributes for additional information. */
-  "crossorigin": (value: "" | "anonymous" | "use-credentials") => HTMLElements["link"];
-  "disabled": (value: boolean) => HTMLElements["link"];
+  crossorigin: (
+    value: "" | "anonymous" | "use-credentials"
+  ) => HTMLElements["link"];
+  disabled: (value: boolean) => HTMLElements["link"];
   /** This attribute specifies the URL of the linked resource. A URL can be absolute or relative. */
-  "href": (value: string) => HTMLElements["link"];
+  href: (value: string) => HTMLElements["link"];
   /** This attribute indicates the language of the linked resource. It is purely advisory. Allowed values are specified by RFC 5646: Tags for Identifying Languages (also known as BCP 47). Use this attribute only if the href attribute is present. */
-  "hreflang": (value: string) => HTMLElements["link"];
-  "imagesizes": (value: string) => HTMLElements["link"];
-  "imagesrcset": (value: string) => HTMLElements["link"];
-  "integrity": (value: string) => HTMLElements["link"];
+  hreflang: (value: string) => HTMLElements["link"];
+  imagesizes: (value: string) => HTMLElements["link"];
+  imagesrcset: (value: string) => HTMLElements["link"];
+  integrity: (value: string) => HTMLElements["link"];
   /** This attribute specifies the media that the linked resource applies to. Its value must be a media type / media query. This attribute is mainly useful when linking to external stylesheets — it allows the user agent to pick the best adapted one for the device it runs on. Note: In HTML 4, this can only be a simple white-space-separated list of media description literals, i.e., media types and groups, where defined and allowed as values for this attribute, such as print, screen, aural, braille. HTML5 extended this to any kind of media queries, which are a superset of the allowed values of HTML 4. Browsers not supporting CSS3 Media Queries won't necessarily recognize the adequate link; do not forget to set fallback links, the restricted set of media queries defined in HTML 4. */
-  "media": (value: string) => HTMLElements["link"];
+  media: (value: string) => HTMLElements["link"];
   /** The value of this attribute provides information about the functions that might be performed on an object. The values generally are given by the HTTP protocol when it is used, but it might (for similar reasons as for the title attribute) be useful to include advisory information in advance in the link. For example, the browser might choose a different rendering of a link as a function of the methods specified; something that is searchable might get a different icon, or an outside link might render with an indication of leaving the current site. This attribute is not well understood nor supported, even by the defining browser, Internet Explorer 4. */
-  "methods": (value: string) => HTMLElements["link"];
+  methods: (value: string) => HTMLElements["link"];
   /** Identifies a resource that might be required by the next navigation and that the user agent should retrieve it. This allows the user agent to respond faster when the resource is requested in the future. */
-  "prefetch": (value: string) => HTMLElements["link"];
+  prefetch: (value: string) => HTMLElements["link"];
   /** A string indicating which referrer to use when fetching the resource: no-referrer means that the Referer header will not be sent. no-referrer-when-downgrade means that no Referer header will be sent when navigating to an origin without TLS (HTTPS). This is a user agent's default behavior, if no policy is otherwise specified. origin means that the referrer will be the origin of the page, which is roughly the scheme, the host, and the port. origin-when-cross-origin means that navigating to other origins will be limited to the scheme, the host, and the port, while navigating on the same origin will include the referrer's path. unsafe-url means that the referrer will include the origin and the path (but not the fragment, password, or username). This case is unsafe because it can leak origins and paths from TLS-protected resources to insecure origins. */
-  "referrerpolicy": (value: "" | "no-referrer" | "no-referrer-when-downgrade" | "same-origin" | "origin" | "strict-origin" | "origin-when-cross-origin" | "strict-origin-when-cross-origin" | "unsafe-url") => HTMLElements["link"];
-  "rel": (value: string) => HTMLElements["link"];
+  referrerpolicy: (
+    value:
+      | ""
+      | "no-referrer"
+      | "no-referrer-when-downgrade"
+      | "same-origin"
+      | "origin"
+      | "strict-origin"
+      | "origin-when-cross-origin"
+      | "strict-origin-when-cross-origin"
+      | "unsafe-url"
+  ) => HTMLElements["link"];
+  rel: (value: string) => HTMLElements["link"];
   /** @deprecated The value of this attribute shows the relationship of the current document to the linked document, as defined by the href attribute. The attribute thus defines the reverse relationship compared to the value of the rel attribute. Link type values for the attribute are similar to the possible values for rel. Note: Instead of rev, you should use the rel attribute with the opposite link type value. For example, to establish the reverse link for made, specify author. Also this attribute doesn't stand for "revision" and must not be used with a version number, even though many sites misuse it in this way. */
-  "rev": (value: string) => HTMLElements["link"];
-  "role": (value: string) => HTMLElements["link"];
-  "sizes": (value: string) => HTMLElements["link"];
+  rev: (value: string) => HTMLElements["link"];
+  role: (value: string) => HTMLElements["link"];
+  sizes: (value: string) => HTMLElements["link"];
   /** Defines the frame or window name that has the defined linking relationship or that will show the rendering of any linked resource. */
-  "target": (value: string) => HTMLElements["link"];
+  target: (value: string) => HTMLElements["link"];
   /** This attribute is used to define the type of the content linked to. The value of the attribute should be a MIME type such as text/html, text/css, and so on. The common use of this attribute is to define the type of stylesheet being referenced (such as text/css), but given that CSS is the only stylesheet language used on the web, not only is it possible to omit the type attribute, but is actually now recommended practice. It is also used on rel="preload" link types, to make sure the browser only downloads file types that it supports. */
-  "type": (value: string) => HTMLElements["link"];
-} & GlobalAriaAttributes<"link"> & GlobalHTMLAttributes<"link">;
+  type: (value: string) => HTMLElements["link"];
+} & GlobalAriaAttributes<"link"> &
+  GlobalHTMLAttributes<"link">;
 
-type listingElement = {
-} & GlobalAriaAttributes<"listing"> & GlobalHTMLAttributes<"listing">;
+type listingElement = {} & GlobalAriaAttributes<"listing"> &
+  GlobalHTMLAttributes<"listing">;
 
 type mainElement = {
-  "role": (value: string) => HTMLElements["main"];
-} & GlobalAriaAttributes<"main"> & GlobalHTMLAttributes<"main">;
+  role: (value: string) => HTMLElements["main"];
+} & GlobalAriaAttributes<"main"> &
+  GlobalHTMLAttributes<"main">;
 
 type mapElement = {
-  "name": (value: string) => HTMLElements["map"];
-  "role": (value: string) => HTMLElements["map"];
-} & GlobalAriaAttributes<"map"> & GlobalHTMLAttributes<"map">;
+  name: (value: string) => HTMLElements["map"];
+  role: (value: string) => HTMLElements["map"];
+} & GlobalAriaAttributes<"map"> &
+  GlobalHTMLAttributes<"map">;
 
 type markElement = {
-  "role": (value: string) => HTMLElements["mark"];
-} & GlobalAriaAttributes<"mark"> & GlobalHTMLAttributes<"mark">;
+  role: (value: string) => HTMLElements["mark"];
+} & GlobalAriaAttributes<"mark"> &
+  GlobalHTMLAttributes<"mark">;
 
 type marqueeElement = {
   /** Sets how the text is scrolled within the marquee. Possible values are scroll, slide and alternate. If no value is specified, the default value is scroll. */
-  "behavior": (value: string) => HTMLElements["marquee"];
+  behavior: (value: string) => HTMLElements["marquee"];
   /** Sets the background color through color name or hexadecimal value. */
-  "bgcolor": (value: string) => HTMLElements["marquee"];
+  bgcolor: (value: string) => HTMLElements["marquee"];
   /** Sets the direction of the scrolling within the marquee. Possible values are left, right, up and down. If no value is specified, the default value is left. */
-  "direction": (value: string) => HTMLElements["marquee"];
+  direction: (value: string) => HTMLElements["marquee"];
   /** Sets the height in pixels or percentage value. */
-  "height": (value: string) => HTMLElements["marquee"];
+  height: (value: string) => HTMLElements["marquee"];
   /** Sets the horizontal margin */
-  "hspace": (value: string) => HTMLElements["marquee"];
+  hspace: (value: string) => HTMLElements["marquee"];
   /** Sets the number of times the marquee will scroll. If no value is specified, the default value is −1, which means the marquee will scroll continuously. */
-  "loop": (value: string) => HTMLElements["marquee"];
+  loop: (value: string) => HTMLElements["marquee"];
   /** Sets the amount of scrolling at each interval in pixels. The default value is 6. */
-  "scrollamount": (value: string) => HTMLElements["marquee"];
+  scrollamount: (value: string) => HTMLElements["marquee"];
   /** Sets the interval between each scroll movement in milliseconds. The default value is 85. Note that any value smaller than 60 is ignored and the value 60 is used instead, unlesstruespeedis specified. */
-  "scrolldelay": (value: string) => HTMLElements["marquee"];
+  scrolldelay: (value: string) => HTMLElements["marquee"];
   /** By default,scrolldelayvalues lower than 60 are ignored. Iftruespeedis present, those values are not ignored. */
-  "truespeed": (value: string) => HTMLElements["marquee"];
+  truespeed: (value: string) => HTMLElements["marquee"];
   /** Sets the vertical margin in pixels or percentage value. */
-  "vspace": (value: string) => HTMLElements["marquee"];
+  vspace: (value: string) => HTMLElements["marquee"];
   /** Sets the width in pixels or percentage value. */
-  "width": (value: string) => HTMLElements["marquee"];
-} & GlobalAriaAttributes<"marquee"> & GlobalHTMLAttributes<"marquee">;
+  width: (value: string) => HTMLElements["marquee"];
+} & GlobalAriaAttributes<"marquee"> &
+  GlobalHTMLAttributes<"marquee">;
 
 type menuElement = {
-  "role": (value: string) => HTMLElements["menu"];
-} & GlobalAriaAttributes<"menu"> & GlobalHTMLAttributes<"menu">;
+  role: (value: string) => HTMLElements["menu"];
+} & GlobalAriaAttributes<"menu"> &
+  GlobalHTMLAttributes<"menu">;
 
 type menuitemElement = {
   /** Boolean attribute which indicates whether the command is selected. May only be used when the type attribute is checkbox or radio. */
-  "checked": (value: string) => HTMLElements["menuitem"];
+  checked: (value: string) => HTMLElements["menuitem"];
   /** Specifies the ID of a separate element, indicating a command to be invoked indirectly. May not be used within a menu item that also includes the attributes checked, disabled, icon, label, radiogroup or type. */
-  "command": (value: string) => HTMLElements["menuitem"];
+  command: (value: string) => HTMLElements["menuitem"];
   /** This Boolean attribute indicates use of the same command as the menu's subject element (such as a button or input). */
-  "default": (value: string) => HTMLElements["menuitem"];
+  default: (value: string) => HTMLElements["menuitem"];
   /** Boolean attribute which indicates that the command is not available in the current state. Note that disabled is distinct from hidden; the disabled attribute is appropriate in any context where a change in circumstances might render the command relevant. */
-  "disabled": (value: string) => HTMLElements["menuitem"];
+  disabled: (value: string) => HTMLElements["menuitem"];
   /** Image URL, used to provide a picture to represent the command. */
-  "icon": (value: string) => HTMLElements["menuitem"];
+  icon: (value: string) => HTMLElements["menuitem"];
   /** The name of the command as shown to the user. Required when a command attribute is not present. */
-  "label": (value: string) => HTMLElements["menuitem"];
+  label: (value: string) => HTMLElements["menuitem"];
   /** This attribute specifies the name of a group of commands to be toggled as radio buttons when selected. May only be used where the type attribute is radio. */
-  "radiogroup": (value: string) => HTMLElements["menuitem"];
+  radiogroup: (value: string) => HTMLElements["menuitem"];
   /** This attribute indicates the kind of command, and can be one of three values. command: A regular command with an associated action. This is the missing value default. checkbox: Represents a command that can be toggled between two different states. radio: Represent one selection from a group of commands that can be toggled as radio buttons. */
-  "type": (value: string) => HTMLElements["menuitem"];
-} & GlobalAriaAttributes<"menuitem"> & GlobalHTMLAttributes<"menuitem">;
+  type: (value: string) => HTMLElements["menuitem"];
+} & GlobalAriaAttributes<"menuitem"> &
+  GlobalHTMLAttributes<"menuitem">;
 
 type metaElement = {
-  "charset": (value: "utf-8") => HTMLElements["meta"];
-  "content": (value: string) => HTMLElements["meta"];
-  "httpEquiv": (value: "content-type" | "default-style" | "refresh" | "x-ua-compatible" | "content-security-policy") => HTMLElements["meta"];
-  "media": (value: string) => HTMLElements["meta"];
-  "name": (value: string) => HTMLElements["meta"];
-  "role": (value: string) => HTMLElements["meta"];
-} & GlobalAriaAttributes<"meta"> & GlobalHTMLAttributes<"meta">;
+  charset: (value: "utf-8") => HTMLElements["meta"];
+  content: (value: string) => HTMLElements["meta"];
+  httpEquiv: (
+    value:
+      | "content-type"
+      | "default-style"
+      | "refresh"
+      | "x-ua-compatible"
+      | "content-security-policy"
+  ) => HTMLElements["meta"];
+  media: (value: string) => HTMLElements["meta"];
+  name: (value: string) => HTMLElements["meta"];
+  role: (value: string) => HTMLElements["meta"];
+} & GlobalAriaAttributes<"meta"> &
+  GlobalHTMLAttributes<"meta">;
 
 type meterElement = {
   /** The <form> element to associate the <meter> element with (its form owner). The value of this attribute must be the id of a <form> in the same document. If this attribute is not set, the <meter> is associated with its ancestor <form> element, if any. This attribute is only used if the <meter> element is being used as a form-associated element, such as one displaying a range corresponding to an <input type="number">. */
-  "form": (value: string) => HTMLElements["meter"];
-  "high": (value: number) => HTMLElements["meter"];
-  "low": (value: number) => HTMLElements["meter"];
-  "max": (value: number) => HTMLElements["meter"];
-  "min": (value: number) => HTMLElements["meter"];
-  "optimum": (value: number) => HTMLElements["meter"];
-  "role": (value: string) => HTMLElements["meter"];
-  "value": (value: number) => HTMLElements["meter"];
-} & GlobalAriaAttributes<"meter"> & GlobalHTMLAttributes<"meter">;
+  form: (value: string) => HTMLElements["meter"];
+  high: (value: number) => HTMLElements["meter"];
+  low: (value: number) => HTMLElements["meter"];
+  max: (value: number) => HTMLElements["meter"];
+  min: (value: number) => HTMLElements["meter"];
+  optimum: (value: number) => HTMLElements["meter"];
+  role: (value: string) => HTMLElements["meter"];
+  value: (value: number) => HTMLElements["meter"];
+} & GlobalAriaAttributes<"meter"> &
+  GlobalHTMLAttributes<"meter">;
 
-type multicolElement = {
-} & GlobalAriaAttributes<"multicol"> & GlobalHTMLAttributes<"multicol">;
+type multicolElement = {} & GlobalAriaAttributes<"multicol"> &
+  GlobalHTMLAttributes<"multicol">;
 
 type navElement = {
-  "role": (value: string) => HTMLElements["nav"];
-} & GlobalAriaAttributes<"nav"> & GlobalHTMLAttributes<"nav">;
+  role: (value: string) => HTMLElements["nav"];
+} & GlobalAriaAttributes<"nav"> &
+  GlobalHTMLAttributes<"nav">;
 
-type nextidElement = {
-} & GlobalAriaAttributes<"nextid"> & GlobalHTMLAttributes<"nextid">;
+type nextidElement = {} & GlobalAriaAttributes<"nextid"> &
+  GlobalHTMLAttributes<"nextid">;
 
-type nobrElement = {
-} & GlobalAriaAttributes<"nobr"> & GlobalHTMLAttributes<"nobr">;
+type nobrElement = {} & GlobalAriaAttributes<"nobr"> &
+  GlobalHTMLAttributes<"nobr">;
 
-type noembedElement = {
-} & GlobalAriaAttributes<"noembed"> & GlobalHTMLAttributes<"noembed">;
+type noembedElement = {} & GlobalAriaAttributes<"noembed"> &
+  GlobalHTMLAttributes<"noembed">;
 
-type noframesElement = {
-} & GlobalAriaAttributes<"noframes"> & GlobalHTMLAttributes<"noframes">;
+type noframesElement = {} & GlobalAriaAttributes<"noframes"> &
+  GlobalHTMLAttributes<"noframes">;
 
 type noscriptElement = {
-  "role": (value: string) => HTMLElements["noscript"];
-} & GlobalAriaAttributes<"noscript"> & GlobalHTMLAttributes<"noscript">;
+  role: (value: string) => HTMLElements["noscript"];
+} & GlobalAriaAttributes<"noscript"> &
+  GlobalHTMLAttributes<"noscript">;
 
 type objectElement = {
   /** @deprecated A space-separated list of URIs for archives of resources for the object. */
-  "archive": (value: string) => HTMLElements["object"];
+  archive: (value: string) => HTMLElements["object"];
   /** @deprecated The width of a border around the control, in pixels. */
-  "border": (value: string) => HTMLElements["object"];
+  border: (value: string) => HTMLElements["object"];
   /** @deprecated The URI of the object's implementation. It can be used together with, or in place of, the data attribute. */
-  "classid": (value: string) => HTMLElements["object"];
+  classid: (value: string) => HTMLElements["object"];
   /** @deprecated The base path used to resolve relative URIs specified by classid, data, or archive. If not specified, the default is the base URI of the current document. */
-  "codebase": (value: string) => HTMLElements["object"];
+  codebase: (value: string) => HTMLElements["object"];
   /** @deprecated The content type of the data specified by classid. */
-  "codetype": (value: string) => HTMLElements["object"];
-  "data": (value: string) => HTMLElements["object"];
+  codetype: (value: string) => HTMLElements["object"];
+  data: (value: string) => HTMLElements["object"];
   /** @deprecated The presence of this Boolean attribute makes this element a declaration only. The object must be instantiated by a subsequent <object> element. In HTML5, repeat the <object> element completely each time that the resource is reused. */
-  "declare": (value: string) => HTMLElements["object"];
+  declare: (value: string) => HTMLElements["object"];
   /** The form element, if any, that the object element is associated with (its form owner). The value of the attribute must be an ID of a <form> element in the same document. */
-  "form": (value: string) => HTMLElements["object"];
+  form: (value: string) => HTMLElements["object"];
   /** The height of the displayed resource, in CSS pixels. -- (Absolute values only. NO percentages) */
-  "height": (value: number) => HTMLElements["object"];
-  "name": (value: string) => HTMLElements["object"];
-  "role": (value: string) => HTMLElements["object"];
+  height: (value: number) => HTMLElements["object"];
+  name: (value: string) => HTMLElements["object"];
+  role: (value: string) => HTMLElements["object"];
   /** @deprecated A message that the browser can show while loading the object's implementation and data. */
-  "standby": (value: string) => HTMLElements["object"];
-  "type": (value: string) => HTMLElements["object"];
+  standby: (value: string) => HTMLElements["object"];
+  type: (value: string) => HTMLElements["object"];
   /** A hash-name reference to a <map> element; that is a '#' followed by the value of a name of a map element. */
-  "usemap": (value: string) => HTMLElements["object"];
+  usemap: (value: string) => HTMLElements["object"];
   /** The width of the display resource, in CSS pixels. -- (Absolute values only. NO percentages) */
-  "width": (value: number) => HTMLElements["object"];
-} & GlobalAriaAttributes<"object"> & GlobalHTMLAttributes<"object">;
+  width: (value: number) => HTMLElements["object"];
+} & GlobalAriaAttributes<"object"> &
+  GlobalHTMLAttributes<"object">;
 
 type olElement = {
-  "reversed": (value: boolean) => HTMLElements["ol"];
-  "role": (value: string) => HTMLElements["ol"];
-  "start": (value: string) => HTMLElements["ol"];
-  "type": (value: "1" | "a" | "A" | "i" | "I") => HTMLElements["ol"];
-} & GlobalAriaAttributes<"ol"> & GlobalHTMLAttributes<"ol">;
+  reversed: (value: boolean) => HTMLElements["ol"];
+  role: (value: string) => HTMLElements["ol"];
+  start: (value: string) => HTMLElements["ol"];
+  type: (value: "1" | "a" | "A" | "i" | "I") => HTMLElements["ol"];
+} & GlobalAriaAttributes<"ol"> &
+  GlobalHTMLAttributes<"ol">;
 
 type optgroupElement = {
   /** If this Boolean attribute is set, none of the items in this option group is selectable. Often browsers grey out such control and it won't receive any browsing events, like mouse clicks or focus-related ones. */
-  "disabled": (value: boolean) => HTMLElements["optgroup"];
-  "label": (value: string) => HTMLElements["optgroup"];
-  "role": (value: string) => HTMLElements["optgroup"];
-} & GlobalAriaAttributes<"optgroup"> & GlobalHTMLAttributes<"optgroup">;
+  disabled: (value: boolean) => HTMLElements["optgroup"];
+  label: (value: string) => HTMLElements["optgroup"];
+  role: (value: string) => HTMLElements["optgroup"];
+} & GlobalAriaAttributes<"optgroup"> &
+  GlobalHTMLAttributes<"optgroup">;
 
 type optionElement = {
   /** If this Boolean attribute is set, this option is not checkable. Often browsers grey out such control and it won't receive any browsing event, like mouse clicks or focus-related ones. If this attribute is not set, the element can still be disabled if one of its ancestors is a disabled <optgroup> element. */
-  "disabled": (value: boolean) => HTMLElements["option"];
-  "label": (value: string) => HTMLElements["option"];
-  "role": (value: string) => HTMLElements["option"];
-  "selected": (value: boolean) => HTMLElements["option"];
-  "value": (value: string) => HTMLElements["option"];
-} & GlobalAriaAttributes<"option"> & GlobalHTMLAttributes<"option">;
+  disabled: (value: boolean) => HTMLElements["option"];
+  label: (value: string) => HTMLElements["option"];
+  role: (value: string) => HTMLElements["option"];
+  selected: (value: boolean) => HTMLElements["option"];
+  value: (value: string) => HTMLElements["option"];
+} & GlobalAriaAttributes<"option"> &
+  GlobalHTMLAttributes<"option">;
 
 type outputElement = {
-  "for": (value: string) => HTMLElements["output"];
+  for: (value: string) => HTMLElements["output"];
   /** The <form> element to associate the output with (its form owner). The value of this attribute must be the id of a <form> in the same document. (If this attribute is not set, the <output> is associated with its ancestor <form> element, if any.) This attribute lets you associate <output> elements to <form>s anywhere in the document, not just inside a <form>. It can also override an ancestor <form> element. */
-  "form": (value: string) => HTMLElements["output"];
+  form: (value: string) => HTMLElements["output"];
   /** The element's name. Used in the form.elements API. */
-  "name": (value: string) => HTMLElements["output"];
-  "role": (value: string) => HTMLElements["output"];
-} & GlobalAriaAttributes<"output"> & GlobalHTMLAttributes<"output">;
+  name: (value: string) => HTMLElements["output"];
+  role: (value: string) => HTMLElements["output"];
+} & GlobalAriaAttributes<"output"> &
+  GlobalHTMLAttributes<"output">;
 
 type pElement = {
-  "role": (value: string) => HTMLElements["p"];
-} & GlobalAriaAttributes<"p"> & GlobalHTMLAttributes<"p">;
+  role: (value: string) => HTMLElements["p"];
+} & GlobalAriaAttributes<"p"> &
+  GlobalHTMLAttributes<"p">;
 
 type paramElement = {
-  "name": (value: string) => HTMLElements["param"];
-  "role": (value: string) => HTMLElements["param"];
+  name: (value: string) => HTMLElements["param"];
+  role: (value: string) => HTMLElements["param"];
   /** @deprecated Only used if the valuetype is set to ref. Specifies the MIME type of values found at the URI specified by value. */
-  "type": (value: string) => HTMLElements["param"];
-  "value": (value: string) => HTMLElements["param"];
+  type: (value: string) => HTMLElements["param"];
+  value: (value: string) => HTMLElements["param"];
   /** @deprecated Specifies the type of the value attribute. Possible values are: data: Default value. The value is passed to the object's implementation as a string. ref: The value is a URI to a resource where run-time values are stored. object: An ID of another <object> in the same document. */
-  "valuetype": (value: string) => HTMLElements["param"];
-} & GlobalAriaAttributes<"param"> & GlobalHTMLAttributes<"param">;
+  valuetype: (value: string) => HTMLElements["param"];
+} & GlobalAriaAttributes<"param"> &
+  GlobalHTMLAttributes<"param">;
 
 type pictureElement = {
-  "role": (value: string) => HTMLElements["picture"];
-} & GlobalAriaAttributes<"picture"> & GlobalHTMLAttributes<"picture">;
+  role: (value: string) => HTMLElements["picture"];
+} & GlobalAriaAttributes<"picture"> &
+  GlobalHTMLAttributes<"picture">;
 
-type plaintextElement = {
-} & GlobalAriaAttributes<"plaintext"> & GlobalHTMLAttributes<"plaintext">;
+type plaintextElement = {} & GlobalAriaAttributes<"plaintext"> &
+  GlobalHTMLAttributes<"plaintext">;
 
 type portalElement = {
-  "referrerpolicy": (value: "" | "no-referrer" | "no-referrer-when-downgrade" | "same-origin" | "origin" | "strict-origin" | "origin-when-cross-origin" | "strict-origin-when-cross-origin" | "unsafe-url") => HTMLElements["portal"];
-  "role": (value: string) => HTMLElements["portal"];
-  "src": (value: string) => HTMLElements["portal"];
-} & GlobalAriaAttributes<"portal"> & GlobalHTMLAttributes<"portal">;
+  referrerpolicy: (
+    value:
+      | ""
+      | "no-referrer"
+      | "no-referrer-when-downgrade"
+      | "same-origin"
+      | "origin"
+      | "strict-origin"
+      | "origin-when-cross-origin"
+      | "strict-origin-when-cross-origin"
+      | "unsafe-url"
+  ) => HTMLElements["portal"];
+  role: (value: string) => HTMLElements["portal"];
+  src: (value: string) => HTMLElements["portal"];
+} & GlobalAriaAttributes<"portal"> &
+  GlobalHTMLAttributes<"portal">;
 
 type preElement = {
   /** @deprecated Contains the preferred count of characters that a line should have. It was a non-standard synonym of width. To achieve such an effect, use CSS width instead. */
-  "cols": (value: string) => HTMLElements["pre"];
-  "role": (value: string) => HTMLElements["pre"];
+  cols: (value: string) => HTMLElements["pre"];
+  role: (value: string) => HTMLElements["pre"];
   /** @deprecated Contains the preferred count of characters that a line should have. Though technically still implemented, this attribute has no visual effect; to achieve such an effect, use CSS width instead. */
-  "width": (value: string) => HTMLElements["pre"];
+  width: (value: string) => HTMLElements["pre"];
   /** Is a hint indicating how the overflow must happen. In modern browser this hint is ignored and no visual effect results in its present; to achieve such an effect, use CSS white-space instead. */
-  "wrap": (value: string) => HTMLElements["pre"];
-} & GlobalAriaAttributes<"pre"> & GlobalHTMLAttributes<"pre">;
+  wrap: (value: string) => HTMLElements["pre"];
+} & GlobalAriaAttributes<"pre"> &
+  GlobalHTMLAttributes<"pre">;
 
 type progressElement = {
-  "max": (value: number) => HTMLElements["progress"];
-  "role": (value: string) => HTMLElements["progress"];
-  "value": (value: number) => HTMLElements["progress"];
-} & GlobalAriaAttributes<"progress"> & GlobalHTMLAttributes<"progress">;
+  max: (value: number) => HTMLElements["progress"];
+  role: (value: string) => HTMLElements["progress"];
+  value: (value: number) => HTMLElements["progress"];
+} & GlobalAriaAttributes<"progress"> &
+  GlobalHTMLAttributes<"progress">;
 
 type qElement = {
-  "cite": (value: string) => HTMLElements["q"];
-  "role": (value: string) => HTMLElements["q"];
-} & GlobalAriaAttributes<"q"> & GlobalHTMLAttributes<"q">;
+  cite: (value: string) => HTMLElements["q"];
+  role: (value: string) => HTMLElements["q"];
+} & GlobalAriaAttributes<"q"> &
+  GlobalHTMLAttributes<"q">;
 
-type rbElement = {
-} & GlobalAriaAttributes<"rb"> & GlobalHTMLAttributes<"rb">;
+type rbElement = {} & GlobalAriaAttributes<"rb"> & GlobalHTMLAttributes<"rb">;
 
 type rpElement = {
-  "role": (value: string) => HTMLElements["rp"];
-} & GlobalAriaAttributes<"rp"> & GlobalHTMLAttributes<"rp">;
+  role: (value: string) => HTMLElements["rp"];
+} & GlobalAriaAttributes<"rp"> &
+  GlobalHTMLAttributes<"rp">;
 
 type rtElement = {
-  "role": (value: string) => HTMLElements["rt"];
-} & GlobalAriaAttributes<"rt"> & GlobalHTMLAttributes<"rt">;
+  role: (value: string) => HTMLElements["rt"];
+} & GlobalAriaAttributes<"rt"> &
+  GlobalHTMLAttributes<"rt">;
 
-type rtcElement = {
-} & GlobalAriaAttributes<"rtc"> & GlobalHTMLAttributes<"rtc">;
+type rtcElement = {} & GlobalAriaAttributes<"rtc"> &
+  GlobalHTMLAttributes<"rtc">;
 
 type rubyElement = {
-  "role": (value: string) => HTMLElements["ruby"];
-} & GlobalAriaAttributes<"ruby"> & GlobalHTMLAttributes<"ruby">;
+  role: (value: string) => HTMLElements["ruby"];
+} & GlobalAriaAttributes<"ruby"> &
+  GlobalHTMLAttributes<"ruby">;
 
 type sElement = {
-  "role": (value: string) => HTMLElements["s"];
-} & GlobalAriaAttributes<"s"> & GlobalHTMLAttributes<"s">;
+  role: (value: string) => HTMLElements["s"];
+} & GlobalAriaAttributes<"s"> &
+  GlobalHTMLAttributes<"s">;
 
 type sampElement = {
-  "role": (value: string) => HTMLElements["samp"];
-} & GlobalAriaAttributes<"samp"> & GlobalHTMLAttributes<"samp">;
+  role: (value: string) => HTMLElements["samp"];
+} & GlobalAriaAttributes<"samp"> &
+  GlobalHTMLAttributes<"samp">;
 
 type scriptElement = {
-  "async": (value: boolean) => HTMLElements["script"];
-  "blocking": (value: "render") => HTMLElements["script"];
+  async: (value: boolean) => HTMLElements["script"];
+  blocking: (value: "render") => HTMLElements["script"];
   /** @deprecated If present, its value must be an ASCII case-insensitive match for "utf-8". It's unnecessary to specify the charset attribute, because documents must use UTF-8, and the script element inherits its character encoding from the document. */
-  "charset": (value: string) => HTMLElements["script"];
+  charset: (value: string) => HTMLElements["script"];
   /** Normal script elements pass minimal information to the window.onerror for scripts which do not pass the standard CORS checks. To allow error logging for sites which use a separate domain for static media, use this attribute. See CORS settings attributes for a more descriptive explanation of its valid arguments. */
-  "crossorigin": (value: "" | "anonymous" | "use-credentials") => HTMLElements["script"];
-  "defer": (value: boolean) => HTMLElements["script"];
-  "integrity": (value: string) => HTMLElements["script"];
+  crossorigin: (
+    value: "" | "anonymous" | "use-credentials"
+  ) => HTMLElements["script"];
+  defer: (value: boolean) => HTMLElements["script"];
+  integrity: (value: string) => HTMLElements["script"];
   /** @deprecated Like the type attribute, this attribute identifies the scripting language in use. Unlike the type attribute, however, this attribute's possible values were never standardized. The type attribute should be used instead. */
-  "language": (value: string) => HTMLElements["script"];
-  "nomodule": (value: boolean) => HTMLElements["script"];
+  language: (value: string) => HTMLElements["script"];
+  nomodule: (value: boolean) => HTMLElements["script"];
   /** Indicates which referrer to send when fetching the script, or resources fetched by the script: no-referrer: The Referer header will not be sent. no-referrer-when-downgrade: The Referer header will not be sent to origins without TLS (HTTPS). origin: The sent referrer will be limited to the origin of the referring page: its scheme, host, and port. origin-when-cross-origin: The referrer sent to other origins will be limited to the scheme, the host, and the port. Navigations on the same origin will still include the path. same-origin: A referrer will be sent for same origin, but cross-origin requests will contain no referrer information. strict-origin: Only send the origin of the document as the referrer when the protocol security level stays the same (HTTPS→HTTPS), but don't send it to a less secure destination (HTTPS→HTTP). strict-origin-when-cross-origin (default): Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP). unsafe-url: The referrer will include the origin and the path (but not the fragment, password, or username). This value is unsafe, because it leaks origins and paths from TLS-protected resources to insecure origins. Note: An empty string value ("") is both the default value, and a fallback value if referrerpolicy is not supported. If referrerpolicy is not explicitly specified on the <script> element, it will adopt a higher-level referrer policy, i.e. one set on the whole document or domain. If a higher-level policy is not available, the empty string is treated as being equivalent to strict-origin-when-cross-origin. */
-  "referrerpolicy": (value: "" | "no-referrer" | "no-referrer-when-downgrade" | "same-origin" | "origin" | "strict-origin" | "origin-when-cross-origin" | "strict-origin-when-cross-origin" | "unsafe-url") => HTMLElements["script"];
-  "role": (value: string) => HTMLElements["script"];
-  "src": (value: string) => HTMLElements["script"];
-  "type": (value: string) => HTMLElements["script"];
-} & GlobalAriaAttributes<"script"> & GlobalHTMLAttributes<"script">;
+  referrerpolicy: (
+    value:
+      | ""
+      | "no-referrer"
+      | "no-referrer-when-downgrade"
+      | "same-origin"
+      | "origin"
+      | "strict-origin"
+      | "origin-when-cross-origin"
+      | "strict-origin-when-cross-origin"
+      | "unsafe-url"
+  ) => HTMLElements["script"];
+  role: (value: string) => HTMLElements["script"];
+  src: (value: string) => HTMLElements["script"];
+  type: (value: string) => HTMLElements["script"];
+} & GlobalAriaAttributes<"script"> &
+  GlobalHTMLAttributes<"script">;
 
 type sectionElement = {
-  "role": (value: string) => HTMLElements["section"];
-} & GlobalAriaAttributes<"section"> & GlobalHTMLAttributes<"section">;
+  role: (value: string) => HTMLElements["section"];
+} & GlobalAriaAttributes<"section"> &
+  GlobalHTMLAttributes<"section">;
 
 type selectElement = {
   /** A DOMString providing a hint for a user agent's autocomplete feature. See The HTML autocomplete attribute for a complete list of values and details on how to use autocomplete. */
-  "autocomplete": (value: string) => HTMLElements["select"];
+  autocomplete: (value: string) => HTMLElements["select"];
   /** This Boolean attribute indicates that the user cannot interact with the control. If this attribute is not specified, the control inherits its setting from the containing element, for example <fieldset>; if there is no containing element with the disabled attribute set, then the control is enabled. */
-  "disabled": (value: boolean) => HTMLElements["select"];
+  disabled: (value: boolean) => HTMLElements["select"];
   /** The <form> element to associate the <select> with (its form owner). The value of this attribute must be the id of a <form> in the same document. (If this attribute is not set, the <select> is associated with its ancestor <form> element, if any.) This attribute lets you associate <select> elements to <form>s anywhere in the document, not just inside a <form>. It can also override an ancestor <form> element. */
-  "form": (value: string) => HTMLElements["select"];
-  "multiple": (value: boolean) => HTMLElements["select"];
+  form: (value: string) => HTMLElements["select"];
+  multiple: (value: boolean) => HTMLElements["select"];
   /** This attribute is used to specify the name of the control. */
-  "name": (value: string) => HTMLElements["select"];
+  name: (value: string) => HTMLElements["select"];
   /** A Boolean attribute indicating that an option with a non-empty string value must be selected. */
-  "required": (value: boolean) => HTMLElements["select"];
-  "role": (value: string) => HTMLElements["select"];
-  "size": (value: string) => HTMLElements["select"];
-} & GlobalAriaAttributes<"select"> & GlobalHTMLAttributes<"select">;
+  required: (value: boolean) => HTMLElements["select"];
+  role: (value: string) => HTMLElements["select"];
+  size: (value: string) => HTMLElements["select"];
+} & GlobalAriaAttributes<"select"> &
+  GlobalHTMLAttributes<"select">;
 
-type shadowElement = {
-} & GlobalAriaAttributes<"shadow"> & GlobalHTMLAttributes<"shadow">;
+type shadowElement = {} & GlobalAriaAttributes<"shadow"> &
+  GlobalHTMLAttributes<"shadow">;
 
 type slotElement = {
-  "name": (value: string) => HTMLElements["slot"];
-  "role": (value: string) => HTMLElements["slot"];
-} & GlobalAriaAttributes<"slot"> & GlobalHTMLAttributes<"slot">;
+  name: (value: string) => HTMLElements["slot"];
+  role: (value: string) => HTMLElements["slot"];
+} & GlobalAriaAttributes<"slot"> &
+  GlobalHTMLAttributes<"slot">;
 
 type smallElement = {
-  "role": (value: string) => HTMLElements["small"];
-} & GlobalAriaAttributes<"small"> & GlobalHTMLAttributes<"small">;
+  role: (value: string) => HTMLElements["small"];
+} & GlobalAriaAttributes<"small"> &
+  GlobalHTMLAttributes<"small">;
 
 type sourceElement = {
-  "height": (value: number) => HTMLElements["source"];
-  "media": (value: string) => HTMLElements["source"];
-  "role": (value: string) => HTMLElements["source"];
-  "sizes": (value: string) => HTMLElements["source"];
-  "src": (value: string) => HTMLElements["source"];
-  "srcset": (value: string) => HTMLElements["source"];
-  "type": (value: string) => HTMLElements["source"];
-  "width": (value: number) => HTMLElements["source"];
-} & GlobalAriaAttributes<"source"> & GlobalHTMLAttributes<"source">;
+  height: (value: number) => HTMLElements["source"];
+  media: (value: string) => HTMLElements["source"];
+  role: (value: string) => HTMLElements["source"];
+  sizes: (value: string) => HTMLElements["source"];
+  src: (value: string) => HTMLElements["source"];
+  srcset: (value: string) => HTMLElements["source"];
+  type: (value: string) => HTMLElements["source"];
+  width: (value: number) => HTMLElements["source"];
+} & GlobalAriaAttributes<"source"> &
+  GlobalHTMLAttributes<"source">;
 
 type spacerElement = {
   /** This attribute determines alignment of spacer. Possible values are left, right and center. */
-  "align": (value: string) => HTMLElements["spacer"];
+  align: (value: string) => HTMLElements["spacer"];
   /** This attribute can be used for defining height of spacer in pixels when type is block. */
-  "height": (value: string) => HTMLElements["spacer"];
+  height: (value: string) => HTMLElements["spacer"];
   /** This attribute can be used for defining size of spacer in pixels when type is horizontal or vertical. */
-  "size": (value: string) => HTMLElements["spacer"];
+  size: (value: string) => HTMLElements["spacer"];
   /** This attribute determines type of spacer. Possible values are horizontal, vertical and block. */
-  "type": (value: string) => HTMLElements["spacer"];
+  type: (value: string) => HTMLElements["spacer"];
   /** This attribute can be used for defining width of spacer in pixels when type is block. */
-  "width": (value: string) => HTMLElements["spacer"];
-} & GlobalAriaAttributes<"spacer"> & GlobalHTMLAttributes<"spacer">;
+  width: (value: string) => HTMLElements["spacer"];
+} & GlobalAriaAttributes<"spacer"> &
+  GlobalHTMLAttributes<"spacer">;
 
 type spanElement = {
-  "role": (value: string) => HTMLElements["span"];
-} & GlobalAriaAttributes<"span"> & GlobalHTMLAttributes<"span">;
+  role: (value: string) => HTMLElements["span"];
+} & GlobalAriaAttributes<"span"> &
+  GlobalHTMLAttributes<"span">;
 
-type strikeElement = {
-} & GlobalAriaAttributes<"strike"> & GlobalHTMLAttributes<"strike">;
+type strikeElement = {} & GlobalAriaAttributes<"strike"> &
+  GlobalHTMLAttributes<"strike">;
 
 type strongElement = {
-  "role": (value: string) => HTMLElements["strong"];
-} & GlobalAriaAttributes<"strong"> & GlobalHTMLAttributes<"strong">;
+  role: (value: string) => HTMLElements["strong"];
+} & GlobalAriaAttributes<"strong"> &
+  GlobalHTMLAttributes<"strong">;
 
 type styleElement = {
-  "blocking": (value: "render") => HTMLElements["style"];
-  "media": (value: string) => HTMLElements["style"];
-  "role": (value: string) => HTMLElements["style"];
+  blocking: (value: "render") => HTMLElements["style"];
+  media: (value: string) => HTMLElements["style"];
+  role: (value: string) => HTMLElements["style"];
   /** @deprecated This attribute specifies that the styles only apply to the elements of its parent(s) and children. Note: This attribute may be re-introduced in the future per https://github.com/w3c/csswg-drafts/issues/3547. If you want to use the attribute now, you can use a polyfill. */
-  "scoped": (value: string) => HTMLElements["style"];
+  scoped: (value: string) => HTMLElements["style"];
   /** @deprecated This attribute should not be provided: if it is, the only permitted values are the empty string or a case-insensitive match for text/css. */
-  "type": (value: string) => HTMLElements["style"];
-} & GlobalAriaAttributes<"style"> & GlobalHTMLAttributes<"style">;
+  type: (value: string) => HTMLElements["style"];
+} & GlobalAriaAttributes<"style"> &
+  GlobalHTMLAttributes<"style">;
 
 type subElement = {
-  "role": (value: string) => HTMLElements["sub"];
-} & GlobalAriaAttributes<"sub"> & GlobalHTMLAttributes<"sub">;
+  role: (value: string) => HTMLElements["sub"];
+} & GlobalAriaAttributes<"sub"> &
+  GlobalHTMLAttributes<"sub">;
 
 type summaryElement = {
-  "role": (value: string) => HTMLElements["summary"];
-} & GlobalAriaAttributes<"summary"> & GlobalHTMLAttributes<"summary">;
+  role: (value: string) => HTMLElements["summary"];
+} & GlobalAriaAttributes<"summary"> &
+  GlobalHTMLAttributes<"summary">;
 
 type supElement = {
-  "role": (value: string) => HTMLElements["sup"];
-} & GlobalAriaAttributes<"sup"> & GlobalHTMLAttributes<"sup">;
+  role: (value: string) => HTMLElements["sup"];
+} & GlobalAriaAttributes<"sup"> &
+  GlobalHTMLAttributes<"sup">;
 
 type tableElement = {
   /** @deprecated This enumerated attribute indicates how the table must be aligned inside the containing document. It may have the following values: left: the table is displayed on the left side of the document; center: the table is displayed in the center of the document; right: the table is displayed on the right side of the document. Set margin-left and margin-right to auto or margin to 0 auto to achieve an effect that is similar to the align attribute. */
-  "align": (value: string) => HTMLElements["table"];
+  align: (value: string) => HTMLElements["table"];
   /** @deprecated The background color of the table. It is a 6-digit hexadecimal RGB code, prefixed by a '#'. One of the predefined color keywords can also be used. To achieve a similar effect, use the CSS background-color property. */
-  "bgcolor": (value: string) => HTMLElements["table"];
+  bgcolor: (value: string) => HTMLElements["table"];
   /** @deprecated This integer attribute defines, in pixels, the size of the frame surrounding the table. If set to 0, the frame attribute is set to void. To achieve a similar effect, use the CSS border shorthand property. */
-  "border": (value: string) => HTMLElements["table"];
+  border: (value: string) => HTMLElements["table"];
   /** @deprecated This attribute defines the space between the content of a cell and its border, displayed or not. If the cellpadding's length is defined in pixels, this pixel-sized space will be applied to all four sides of the cell's content. If the length is defined using a percentage value, the content will be centered and the total vertical space (top and bottom) will represent this value. The same is true for the total horizontal space (left and right). To achieve a similar effect, apply the border-collapse property to the <table> element, with its value set to collapse, and the padding property to the <td> elements. */
-  "cellpadding": (value: string) => HTMLElements["table"];
+  cellpadding: (value: string) => HTMLElements["table"];
   /** @deprecated This attribute defines the size of the space between two cells in a percentage value or pixels. The attribute is applied both horizontally and vertically, to the space between the top of the table and the cells of the first row, the left of the table and the first column, the right of the table and the last column and the bottom of the table and the last row. To achieve a similar effect, apply the border-spacing property to the <table> element. border-spacing does not have any effect if border-collapse is set to collapse. */
-  "cellspacing": (value: string) => HTMLElements["table"];
+  cellspacing: (value: string) => HTMLElements["table"];
   /** @deprecated This enumerated attribute defines which side of the frame surrounding the table must be displayed. To achieve a similar effect, use the border-style and border-width properties. */
-  "frame": (value: string) => HTMLElements["table"];
-  "role": (value: string) => HTMLElements["table"];
+  frame: (value: string) => HTMLElements["table"];
+  role: (value: string) => HTMLElements["table"];
   /** @deprecated This enumerated attribute defines where rules, i.e. lines, should appear in a table. It can have the following values: none, which indicates that no rules will be displayed; it is the default value; groups, which will cause the rules to be displayed between row groups (defined by the <thead>, <tbody> and <tfoot> elements) and between column groups (defined by the <col> and <colgroup> elements) only; rows, which will cause the rules to be displayed between rows; columns, which will cause the rules to be displayed between columns; all, which will cause the rules to be displayed between rows and columns. To achieve a similar effect, apply the border property to the appropriate <thead>, <tbody>, <tfoot>, <col>, or <colgroup> elements. */
-  "rules": (value: string) => HTMLElements["table"];
+  rules: (value: string) => HTMLElements["table"];
   /** @deprecated This attribute defines an alternative text that summarizes the content of the table. Use the <caption> element instead. */
-  "summary": (value: string) => HTMLElements["table"];
+  summary: (value: string) => HTMLElements["table"];
   /** @deprecated This attribute defines the width of the table. Use the CSS width property instead. */
-  "width": (value: string) => HTMLElements["table"];
-} & GlobalAriaAttributes<"table"> & GlobalHTMLAttributes<"table">;
+  width: (value: string) => HTMLElements["table"];
+} & GlobalAriaAttributes<"table"> &
+  GlobalHTMLAttributes<"table">;
 
 type tbodyElement = {
   /** @deprecated This enumerated attribute specifies how horizontal alignment of each cell content will be handled. Possible values are: left, aligning the content to the left of the cell center, centering the content in the cell right, aligning the content to the right of the cell justify, inserting spaces into the textual content so that the content is justified in the cell char, aligning the textual content on a special character with a minimal offset, defined by the char and charoff attributes. If this attribute is not set, the left value is assumed. As this attribute is deprecated, use the CSS text-align property instead. Note: The equivalent text-align property for the align="char" is not implemented in any browsers yet. See the text-align's browser compatibility section for the <string> value. */
-  "align": (value: string) => HTMLElements["tbody"];
+  align: (value: string) => HTMLElements["tbody"];
   /** @deprecated The background color of the table. It is a 6-digit hexadecimal RGB code, prefixed by a '#'. One of the predefined color keywords can also be used. As this attribute is deprecated, use the CSS background-color property instead. */
-  "bgcolor": (value: string) => HTMLElements["tbody"];
+  bgcolor: (value: string) => HTMLElements["tbody"];
   /** @deprecated This attribute is used to set the character to align the cells in a column on. Typical values for this include a period (.) when attempting to align numbers or monetary values. If align is not set to char, this attribute is ignored. */
-  "char": (value: string) => HTMLElements["tbody"];
+  char: (value: string) => HTMLElements["tbody"];
   /** @deprecated This attribute is used to indicate the number of characters to offset the column data from the alignment characters specified by the char attribute. */
-  "charoff": (value: string) => HTMLElements["tbody"];
-  "role": (value: string) => HTMLElements["tbody"];
+  charoff: (value: string) => HTMLElements["tbody"];
+  role: (value: string) => HTMLElements["tbody"];
   /** @deprecated This attribute specifies the vertical alignment of the text within each row of cells of the table header. Possible values for this attribute are: baseline, which will put the text as close to the bottom of the cell as it is possible, but align it on the baseline of the characters instead of the bottom of them. If characters are all of the size, this has the same effect as bottom. bottom, which will put the text as close to the bottom of the cell as it is possible; middle, which will center the text in the cell; and top, which will put the text as close to the top of the cell as it is possible. As this attribute is deprecated, use the CSS vertical-align property instead. */
-  "valign": (value: string) => HTMLElements["tbody"];
-} & GlobalAriaAttributes<"tbody"> & GlobalHTMLAttributes<"tbody">;
+  valign: (value: string) => HTMLElements["tbody"];
+} & GlobalAriaAttributes<"tbody"> &
+  GlobalHTMLAttributes<"tbody">;
 
 type tdElement = {
   /** @deprecated This attribute contains a short abbreviated description of the cell's content. Some user-agents, such as speech readers, may present this description before the content itself. Note: Do not use this attribute as it is obsolete in the latest standard. Alternatively, you can put the abbreviated description inside the cell and place the long content in the title attribute. */
-  "abbr": (value: string) => HTMLElements["td"];
+  abbr: (value: string) => HTMLElements["td"];
   /** @deprecated This enumerated attribute specifies how the cell content's horizontal alignment will be handled. Possible values are: left: The content is aligned to the left of the cell. center: The content is centered in the cell. right: The content is aligned to the right of the cell. justify (with text only): The content is stretched out inside the cell so that it covers its entire width. char (with text only): The content is aligned to a character inside the <th> element with minimal offset. This character is defined by the char and charoff attributes Unimplemented (see bug 2212). The default value when this attribute is not specified is left. Note: To achieve the same effect as the left, center, right or justify values, apply the CSS text-align property to the element. To achieve the same effect as the char value, give the text-align property the same value you would use for the char. Unimplemented in CSS3. */
-  "align": (value: string) => HTMLElements["td"];
+  align: (value: string) => HTMLElements["td"];
   /** @deprecated This attribute contains a list of space-separated strings. Each string is the id of a group of cells that this header applies to. */
-  "axis": (value: string) => HTMLElements["td"];
+  axis: (value: string) => HTMLElements["td"];
   /** @deprecated This attribute defines the background color of each cell in a column. It is a 6-digit hexadecimal RGB code, prefixed by a '#'. One of the predefined color keywords can also be used. To achieve a similar effect, use the CSS background-color property. */
-  "bgcolor": (value: string) => HTMLElements["td"];
+  bgcolor: (value: string) => HTMLElements["td"];
   /** @deprecated The content in the cell element is aligned to a character. Typical values include a period (.) to align numbers or monetary values. If align is not set to char, this attribute is ignored. */
-  "char": (value: string) => HTMLElements["td"];
+  char: (value: string) => HTMLElements["td"];
   /** @deprecated This attribute is used to shift column data to the right of the character specified by the char attribute. Its value specifies the length of this shift. */
-  "charoff": (value: string) => HTMLElements["td"];
+  charoff: (value: string) => HTMLElements["td"];
   /** This attribute contains a non-negative integer value that indicates for how many columns the cell extends. Its default value is 1. Values higher than 1000 will be considered as incorrect and will be set to the default value (1). */
-  "colspan": (value: string) => HTMLElements["td"];
+  colspan: (value: string) => HTMLElements["td"];
   /** This attribute contains a list of space-separated strings, each corresponding to the id attribute of the <th> elements that apply to this element. */
-  "headers": (value: string) => HTMLElements["td"];
+  headers: (value: string) => HTMLElements["td"];
   /** @deprecated This attribute is used to define a recommended cell height. Use the CSS height property instead. */
-  "height": (value: string) => HTMLElements["td"];
-  "role": (value: string) => HTMLElements["td"];
+  height: (value: string) => HTMLElements["td"];
+  role: (value: string) => HTMLElements["td"];
   /** This attribute contains a non-negative integer value that indicates for how many rows the cell extends. Its default value is 1; if its value is set to 0, it extends until the end of the table section (<thead>, <tbody>, <tfoot>, even if implicitly defined), that the cell belongs to. Values higher than 65534 are clipped down to 65534. */
-  "rowspan": (value: string) => HTMLElements["td"];
+  rowspan: (value: string) => HTMLElements["td"];
   /** @deprecated This enumerated attribute defines the cells that the header (defined in the <th>) element relates to. Only use this attribute with the <th> element to define the row or column for which it is a header. */
-  "scope": (value: string) => HTMLElements["td"];
+  scope: (value: string) => HTMLElements["td"];
   /** @deprecated This attribute specifies how a text is vertically aligned inside a cell. Possible values for this attribute are: baseline: Positions the text near the bottom of the cell and aligns it with the baseline of the characters instead of the bottom. If characters don't descend below the baseline, the baseline value achieves the same effect as bottom. bottom: Positions the text near the bottom of the cell. middle: Centers the text in the cell. and top: Positions the text near the top of the cell. To achieve a similar effect, use the CSS vertical-align property. */
-  "valign": (value: string) => HTMLElements["td"];
+  valign: (value: string) => HTMLElements["td"];
   /** @deprecated This attribute is used to define a recommended cell width. Use the CSS width property instead. */
-  "width": (value: string) => HTMLElements["td"];
-} & GlobalAriaAttributes<"td"> & GlobalHTMLAttributes<"td">;
+  width: (value: string) => HTMLElements["td"];
+} & GlobalAriaAttributes<"td"> &
+  GlobalHTMLAttributes<"td">;
 
 type templateElement = {
-  "role": (value: string) => HTMLElements["template"];
-} & GlobalAriaAttributes<"template"> & GlobalHTMLAttributes<"template">;
+  role: (value: string) => HTMLElements["template"];
+} & GlobalAriaAttributes<"template"> &
+  GlobalHTMLAttributes<"template">;
 
 type textareaElement = {
   /** This attribute indicates whether the value of the control can be automatically completed by the browser. Possible values are: off: The user must explicitly enter a value into this field for every use, or the document provides its own auto-completion method; the browser does not automatically complete the entry. on: The browser can automatically complete the value based on values that the user has entered during previous uses. If the autocomplete attribute is not specified on a <textarea> element, then the browser uses the autocomplete attribute value of the <textarea> element's form owner. The form owner is either the <form> element that this <textarea> element is a descendant of or the form element whose id is specified by the form attribute of the input element. For more information, see the autocomplete attribute in <form>. */
-  "autocomplete": (value: string) => HTMLElements["textarea"];
+  autocomplete: (value: string) => HTMLElements["textarea"];
   /** A string which indicates whether or not to activate automatic spelling correction and processing of text substitutions (if any are configured) while the user is editing this textarea. Permitted values are: on Enable automatic spelling correction and text substitutions. off Disable automatic spelling correction and text substitutions. */
-  "autocorrect": (value: string) => HTMLElements["textarea"];
-  "cols": (value: string) => HTMLElements["textarea"];
-  "dirname": (value: string) => HTMLElements["textarea"];
+  autocorrect: (value: string) => HTMLElements["textarea"];
+  cols: (value: string) => HTMLElements["textarea"];
+  dirname: (value: string) => HTMLElements["textarea"];
   /** This Boolean attribute indicates that the user cannot interact with the control. If this attribute is not specified, the control inherits its setting from the containing element, for example <fieldset>; if there is no containing element when the disabled attribute is set, the control is enabled. */
-  "disabled": (value: boolean) => HTMLElements["textarea"];
+  disabled: (value: boolean) => HTMLElements["textarea"];
   /** The form element that the <textarea> element is associated with (its "form owner"). The value of the attribute must be the id of a form element in the same document. If this attribute is not specified, the <textarea> element must be a descendant of a form element. This attribute enables you to place <textarea> elements anywhere within a document, not just as descendants of form elements. */
-  "form": (value: string) => HTMLElements["textarea"];
+  form: (value: string) => HTMLElements["textarea"];
   /** The maximum number of characters (UTF-16 code units) that the user can enter. If this value isn't specified, the user can enter an unlimited number of characters. */
-  "maxlength": (value: number) => HTMLElements["textarea"];
+  maxlength: (value: number) => HTMLElements["textarea"];
   /** The minimum number of characters (UTF-16 code units) required that the user should enter. */
-  "minlength": (value: number) => HTMLElements["textarea"];
+  minlength: (value: number) => HTMLElements["textarea"];
   /** The name of the control. */
-  "name": (value: string) => HTMLElements["textarea"];
-  "placeholder": (value: string) => HTMLElements["textarea"];
+  name: (value: string) => HTMLElements["textarea"];
+  placeholder: (value: string) => HTMLElements["textarea"];
   /** This Boolean attribute indicates that the user cannot modify the value of the control. Unlike the disabled attribute, the readonly attribute does not prevent the user from clicking or selecting in the control. The value of a read-only control is still submitted with the form. */
-  "readonly": (value: boolean) => HTMLElements["textarea"];
+  readonly: (value: boolean) => HTMLElements["textarea"];
   /** This attribute specifies that the user must fill in a value before submitting a form. */
-  "required": (value: boolean) => HTMLElements["textarea"];
-  "role": (value: string) => HTMLElements["textarea"];
-  "rows": (value: string) => HTMLElements["textarea"];
-  "wrap": (value: "soft" | "hard") => HTMLElements["textarea"];
-} & GlobalAriaAttributes<"textarea"> & GlobalHTMLAttributes<"textarea">;
+  required: (value: boolean) => HTMLElements["textarea"];
+  role: (value: string) => HTMLElements["textarea"];
+  rows: (value: string) => HTMLElements["textarea"];
+  wrap: (value: "soft" | "hard") => HTMLElements["textarea"];
+} & GlobalAriaAttributes<"textarea"> &
+  GlobalHTMLAttributes<"textarea">;
 
 type tfootElement = {
   /** @deprecated This enumerated attribute specifies how horizontal alignment of each cell content will be handled. Possible values are: left, aligning the content to the left of the cell center, centering the content in the cell right, aligning the content to the right of the cell justify, inserting spaces into the textual content so that the content is justified in the cell char, aligning the textual content on a special character with a minimal offset, defined by the char and charoff attributes. If this attribute is not set, the left value is assumed. Note: To achieve the same effect as the left, center, right or justify values, use the CSS text-align property on it. To achieve the same effect as the char value, in CSS3, you can use the value of the char as the value of the text-align property Unimplemented. */
-  "align": (value: string) => HTMLElements["tfoot"];
+  align: (value: string) => HTMLElements["tfoot"];
   /** @deprecated The background color of the table. It is a 6-digit hexadecimal RGB code, prefixed by a '#'. One of the predefined color keywords can also be used. To achieve a similar effect, use the CSS background-color property. */
-  "bgcolor": (value: string) => HTMLElements["tfoot"];
+  bgcolor: (value: string) => HTMLElements["tfoot"];
   /** @deprecated This attribute specifies the alignment of the content in a column to a character. Typical values for this include a period (.) when attempting to align numbers or monetary values. If align is not set to char, this attribute is ignored. */
-  "char": (value: string) => HTMLElements["tfoot"];
+  char: (value: string) => HTMLElements["tfoot"];
   /** @deprecated This attribute is used to indicate the number of characters to offset the column data from the alignment characters specified by the char attribute. */
-  "charoff": (value: string) => HTMLElements["tfoot"];
-  "role": (value: string) => HTMLElements["tfoot"];
+  charoff: (value: string) => HTMLElements["tfoot"];
+  role: (value: string) => HTMLElements["tfoot"];
   /** @deprecated This attribute specifies the vertical alignment of the text within each row of cells of the table footer. Possible values for this attribute are: baseline, which will put the text as close to the bottom of the cell as it is possible, but align it on the baseline of the characters instead of the bottom of them. If characters are all of the size, this has the same effect as bottom. bottom, which will put the text as close to the bottom of the cell as it is possible; middle, which will center the text in the cell; and top, which will put the text as close to the top of the cell as it is possible. Note: Do not use this attribute as it is obsolete (and not supported) in the latest standard: instead set the CSS vertical-align property on it. */
-  "valign": (value: string) => HTMLElements["tfoot"];
-} & GlobalAriaAttributes<"tfoot"> & GlobalHTMLAttributes<"tfoot">;
+  valign: (value: string) => HTMLElements["tfoot"];
+} & GlobalAriaAttributes<"tfoot"> &
+  GlobalHTMLAttributes<"tfoot">;
 
 type thElement = {
-  "abbr": (value: string) => HTMLElements["th"];
+  abbr: (value: string) => HTMLElements["th"];
   /** @deprecated This enumerated attribute specifies how the cell content's horizontal alignment will be handled. Possible values are: left: The content is aligned to the left of the cell. center: The content is centered in the cell. right: The content is aligned to the right of the cell. justify (with text only): The content is stretched out inside the cell so that it covers its entire width. char (with text only): The content is aligned to a character inside the <th> element with minimal offset. This character is defined by the char and charoff attributes. The default value when this attribute is not specified is left. Note: Do not use this attribute as it is obsolete in the latest standard. To achieve the same effect as the left, center, right or justify values, apply the CSS text-align property to the element. To achieve the same effect as the char value, give the text-align property the same value you would use for the char. */
-  "align": (value: string) => HTMLElements["th"];
+  align: (value: string) => HTMLElements["th"];
   /** @deprecated This attribute contains a list of space-separated strings. Each string is the id of a group of cells that this header applies to. Note: Do not use this attribute as it is obsolete in the latest standard: use the scope attribute instead. */
-  "axis": (value: string) => HTMLElements["th"];
+  axis: (value: string) => HTMLElements["th"];
   /** @deprecated This attribute defines the background color of each cell in a column. It consists of a 6-digit hexadecimal code as defined in sRGB and is prefixed by '#'. This attribute may be used with one of sixteen predefined color strings: black = "#000000" green = "#008000" silver = "#C0C0C0" lime = "#00FF00" gray = "#808080" olive = "#808000" white = "#FFFFFF" yellow = "#FFFF00" maroon = "#800000" navy = "#000080" red = "#FF0000" blue = "#0000FF" purple = "#800080" teal = "#008080" fuchsia = "#FF00FF" aqua = "#00FFFF" Note: Do not use this attribute, as it is non-standard and only implemented in some versions of Microsoft Internet Explorer: The <th> element should be styled using CSS. To create a similar effect use the background-color property in CSS instead. */
-  "bgcolor": (value: string) => HTMLElements["th"];
+  bgcolor: (value: string) => HTMLElements["th"];
   /** @deprecated The content in the cell element is aligned to a character. Typical values include a period (.) to align numbers or monetary values. If align is not set to char, this attribute is ignored. Note: Do not use this attribute as it is obsolete in the latest standard. To achieve the same effect, you can specify the character as the first value of the text-align property. */
-  "char": (value: string) => HTMLElements["th"];
+  char: (value: string) => HTMLElements["th"];
   /** @deprecated This attribute is used to shift column data to the right of the character specified by the char attribute. Its value specifies the length of this shift. Note: Do not use this attribute as it is obsolete in the latest standard. */
-  "charoff": (value: string) => HTMLElements["th"];
+  charoff: (value: string) => HTMLElements["th"];
   /** This attribute contains a non-negative integer value that indicates for how many columns the cell extends. Its default value is 1. Values higher than 1000 will be considered as incorrect and will be set to the default value (1). */
-  "colspan": (value: string) => HTMLElements["th"];
+  colspan: (value: string) => HTMLElements["th"];
   /** This attribute contains a list of space-separated strings, each corresponding to the id attribute of the <th> elements that apply to this element. */
-  "headers": (value: string) => HTMLElements["th"];
+  headers: (value: string) => HTMLElements["th"];
   /** @deprecated This attribute is used to define a recommended cell height. Note: Do not use this attribute as it is obsolete in the latest standard: use the CSS height property instead. */
-  "height": (value: string) => HTMLElements["th"];
-  "role": (value: string) => HTMLElements["th"];
+  height: (value: string) => HTMLElements["th"];
+  role: (value: string) => HTMLElements["th"];
   /** This attribute contains a non-negative integer value that indicates for how many rows the cell extends. Its default value is 1; if its value is set to 0, it extends until the end of the table section (<thead>, <tbody>, <tfoot>, even if implicitly defined), that the cell belongs to. Values higher than 65534 are clipped down to 65534. */
-  "rowspan": (value: string) => HTMLElements["th"];
-  "scope": (value: "row" | "col" | "rowgroup" | "colgroup") => HTMLElements["th"];
+  rowspan: (value: string) => HTMLElements["th"];
+  scope: (value: "row" | "col" | "rowgroup" | "colgroup") => HTMLElements["th"];
   /** @deprecated This attribute specifies how a text is vertically aligned inside a cell. Possible values for this attribute are: baseline: Positions the text near the bottom of the cell and aligns it with the baseline of the characters instead of the bottom. If characters don't descend below the baseline, the baseline value achieves the same effect as bottom. bottom: Positions the text near the bottom of the cell. middle: Centers the text in the cell. and top: Positions the text near the top of the cell. Note: Do not use this attribute as it is obsolete in the latest standard: use the CSS vertical-align property instead. */
-  "valign": (value: string) => HTMLElements["th"];
+  valign: (value: string) => HTMLElements["th"];
   /** @deprecated This attribute is used to define a recommended cell width. Additional space can be added with the cellspacing and cellpadding properties and the width of the <col> element can also create extra width. But, if a column's width is too narrow to show a particular cell properly, it will be widened when displayed. Note: Do not use this attribute as it is obsolete in the latest standard: use the CSS width property instead. */
-  "width": (value: string) => HTMLElements["th"];
-} & GlobalAriaAttributes<"th"> & GlobalHTMLAttributes<"th">;
+  width: (value: string) => HTMLElements["th"];
+} & GlobalAriaAttributes<"th"> &
+  GlobalHTMLAttributes<"th">;
 
 type theadElement = {
   /** @deprecated This enumerated attribute specifies how horizontal alignment of each cell content will be handled. Possible values are: left, aligning the content to the left of the cell center, centering the content in the cell right, aligning the content to the right of the cell justify, inserting spaces into the textual content so that the content is justified in the cell char, aligning the textual content on a special character with a minimal offset, defined by the char and charoff attributes. If this attribute is not set, the left value is assumed. Warning: Do not use this attribute as it is obsolete (not supported) in the latest standard. To achieve the same effect as the left, center, right or justify values, use the CSS text-align property on it. To achieve the same effect as the char value, in CSS3, you can use the value of the char as the value of the text-align property. */
-  "align": (value: string) => HTMLElements["thead"];
+  align: (value: string) => HTMLElements["thead"];
   /** @deprecated This attribute defines the background color of each cell of the column. It is one of the 6-digit hexadecimal code as defined in sRGB, prefixed by a '#'. One of the sixteen predefined color strings may be used: black = "#000000" green = "#008000" silver = "#C0C0C0" lime = "#00FF00" gray = "#808080" olive = "#808000" white = "#FFFFFF" yellow = "#FFFF00" maroon = "#800000" navy = "#000080" red = "#FF0000" blue = "#0000FF" purple = "#800080" teal = "#008080" fuchsia = "#FF00FF" aqua = "#00FFFF" Note: Do not use this attribute, as it is non-standard and only implemented in some versions of Microsoft Internet Explorer: the <thead> element should be styled using CSS. To give a similar effect to the bgcolor attribute, use the CSS property background-color, on the relevant <td> or <th> elements. */
-  "bgcolor": (value: string) => HTMLElements["thead"];
+  bgcolor: (value: string) => HTMLElements["thead"];
   /** @deprecated This attribute is used to set the character to align the cells in a column on. Typical values for this include a period (.) when attempting to align numbers or monetary values. If align is not set to char, this attribute is ignored. Note: Do not use this attribute as it is obsolete (and not supported) in the latest standard. To achieve the same effect as the char, in CSS3, you can use the character set using the char attribute as the value of the text-align property. */
-  "char": (value: string) => HTMLElements["thead"];
+  char: (value: string) => HTMLElements["thead"];
   /** @deprecated This attribute is used to indicate the number of characters to offset the column data from the alignment characters specified by the char attribute. Note: Do not use this attribute as it is obsolete (and not supported) in the latest standard. */
-  "charoff": (value: string) => HTMLElements["thead"];
-  "role": (value: string) => HTMLElements["thead"];
+  charoff: (value: string) => HTMLElements["thead"];
+  role: (value: string) => HTMLElements["thead"];
   /** @deprecated This attribute specifies the vertical alignment of the text within each row of cells of the table header. Possible values for this attribute are: baseline, which will put the text as close to the bottom of the cell as it is possible, but align it on the baseline of the characters instead of the bottom of them. If characters are all of the size, this has the same effect as bottom. bottom, which will put the text as close to the bottom of the cell as it is possible; middle, which will center the text in the cell; top, which will put the text as close to the top of the cell as it is possible. Note: Do not use this attribute as it is obsolete (and not supported) in the latest standard: instead set the CSS vertical-align property on it. */
-  "valign": (value: string) => HTMLElements["thead"];
-} & GlobalAriaAttributes<"thead"> & GlobalHTMLAttributes<"thead">;
+  valign: (value: string) => HTMLElements["thead"];
+} & GlobalAriaAttributes<"thead"> &
+  GlobalHTMLAttributes<"thead">;
 
 type timeElement = {
-  "datetime": (value: string) => HTMLElements["time"];
-  "role": (value: string) => HTMLElements["time"];
-} & GlobalAriaAttributes<"time"> & GlobalHTMLAttributes<"time">;
+  datetime: (value: string) => HTMLElements["time"];
+  role: (value: string) => HTMLElements["time"];
+} & GlobalAriaAttributes<"time"> &
+  GlobalHTMLAttributes<"time">;
 
 type titleElement = {
-  "role": (value: string) => HTMLElements["title"];
-} & GlobalAriaAttributes<"title"> & GlobalHTMLAttributes<"title">;
+  role: (value: string) => HTMLElements["title"];
+} & GlobalAriaAttributes<"title"> &
+  GlobalHTMLAttributes<"title">;
 
 type trElement = {
   /** @deprecated A DOMString which specifies how the cell's context should be aligned horizontally within the cells in the row; this is shorthand for using align on every cell in the row individually. Possible values are: left Align the content of each cell at its left edge. center Center the contents of each cell between their left and right edges. right Align the content of each cell at its right edge. justify Widen whitespaces within the text of each cell so that the text fills the full width of each cell (full justification). char Align each cell in the row on a specific character (such that each row in the column that is configured this way will horizontally align its cells on that character). This uses the char and charoff to establish the alignment character (typically "." or "," when aligning numerical data) and the number of characters that should follow the alignment character. This alignment type was never widely supported. If no value is expressly set for align, the parent node's value is inherited. Note: Instead of using the obsolete align attribute, you should instead use the CSS text-align property to establish left, center, right, or justify alignment for the row's cells. To apply character-based alignment, set the CSS text-align property to the alignment character (such as "." or ","). */
-  "align": (value: string) => HTMLElements["tr"];
+  align: (value: string) => HTMLElements["tr"];
   /** @deprecated A DOMString specifying a color to apply to the backgrounds of each of the row's cells. This can be either an hexadecimal #RRGGBB or #RGB value or a color keyword. Omitting the attribute or setting it to null in JavaScript causes the row's cells to inherit the row's parent element's background color. Note: The <tr> element should be styled using CSS. To give a similar effect as the bgcolor attribute, use the CSS property background-color. */
-  "bgcolor": (value: string) => HTMLElements["tr"];
+  bgcolor: (value: string) => HTMLElements["tr"];
   /** @deprecated A DOMString which sets the character to align the cells in each of the row's columns on (each row's centering that uses the same character gets aligned with others using the same character . Typical values for this include a period (".") or comma (",") when attempting to align numbers or monetary values. If align is not set to char, this attribute is ignored. Note: This attribute is not only obsolete, but was rarely implemented anyway. To achieve the same effect as the char attribute, set the CSS text-align property to the same string you would specify for the char property, such as text-align: ".". */
-  "char": (value: string) => HTMLElements["tr"];
+  char: (value: string) => HTMLElements["tr"];
   /** @deprecated A DOMString indicating the number of characters on the tail end of the column's data should be displayed after the alignment character specified by the char attribute. For example, when displaying money values for currencies that use hundredths of a unit (such as the dollar, which is divided into 100 cents), you would typically specify a value of 2, so that in tandem with char being set to ".", the values in a column would be cleanly aligned on the decimal points, with the number of cents properly displayed to the right of the decimal point. Note: This attribute is obsolete, and was never widely supported anyway. */
-  "charoff": (value: string) => HTMLElements["tr"];
-  "role": (value: string) => HTMLElements["tr"];
+  charoff: (value: string) => HTMLElements["tr"];
+  role: (value: string) => HTMLElements["tr"];
   /** @deprecated A DOMString specifying the vertical alignment of the text within each cell in the row. Possible values for this attribute are: baseline Aligns each cell's content text as closely as possible to the bottom of the cell, handling alignment of different fonts and font sizes by aligning the characters along the baseline of the font(s) used in the row. If all of the characters in the row are the same size, the effect is the same as bottom. bottom, Draws the text in each of the row's cells as closely as possible to the bottom edge of those cells. middle Each cell's text is vertically centered. top Each cell's text is drawn as closely as possible to the top edge of the containing cell. Note: Don't use the obsolete valign attribute. Instead, add the CSS vertical-align property to the row. */
-  "valign": (value: string) => HTMLElements["tr"];
-} & GlobalAriaAttributes<"tr"> & GlobalHTMLAttributes<"tr">;
+  valign: (value: string) => HTMLElements["tr"];
+} & GlobalAriaAttributes<"tr"> &
+  GlobalHTMLAttributes<"tr">;
 
 type trackElement = {
-  "default": (value: boolean) => HTMLElements["track"];
-  "kind": (value: "subtitles" | "captions" | "descriptions" | "chapters" | "metadata") => HTMLElements["track"];
-  "label": (value: string) => HTMLElements["track"];
-  "role": (value: string) => HTMLElements["track"];
-  "src": (value: string) => HTMLElements["track"];
-  "srclang": (value: string) => HTMLElements["track"];
-} & GlobalAriaAttributes<"track"> & GlobalHTMLAttributes<"track">;
+  default: (value: boolean) => HTMLElements["track"];
+  kind: (
+    value: "subtitles" | "captions" | "descriptions" | "chapters" | "metadata"
+  ) => HTMLElements["track"];
+  label: (value: string) => HTMLElements["track"];
+  role: (value: string) => HTMLElements["track"];
+  src: (value: string) => HTMLElements["track"];
+  srclang: (value: string) => HTMLElements["track"];
+} & GlobalAriaAttributes<"track"> &
+  GlobalHTMLAttributes<"track">;
 
-type ttElement = {
-} & GlobalAriaAttributes<"tt"> & GlobalHTMLAttributes<"tt">;
+type ttElement = {} & GlobalAriaAttributes<"tt"> & GlobalHTMLAttributes<"tt">;
 
 type uElement = {
-  "role": (value: string) => HTMLElements["u"];
-} & GlobalAriaAttributes<"u"> & GlobalHTMLAttributes<"u">;
+  role: (value: string) => HTMLElements["u"];
+} & GlobalAriaAttributes<"u"> &
+  GlobalHTMLAttributes<"u">;
 
 type ulElement = {
   /** @deprecated This Boolean attribute hints that the list should be rendered in a compact style. The interpretation of this attribute depends on the user agent, and it doesn't work in all browsers. Warning: Do not use this attribute, as it has been deprecated: use CSS instead. To give a similar effect as the compact attribute, the CSS property line-height can be used with a value of 80%. */
-  "compact": (value: string) => HTMLElements["ul"];
-  "role": (value: string) => HTMLElements["ul"];
+  compact: (value: string) => HTMLElements["ul"];
+  role: (value: string) => HTMLElements["ul"];
   /** @deprecated This attribute sets the bullet style for the list. The values defined under HTML3.2 and the transitional version of HTML 4.0/4.01 are: circle disc square A fourth bullet type has been defined in the WebTV interface, but not all browsers support it: triangle. If not present and if no CSS list-style-type property applies to the element, the user agent selects a bullet type depending on the nesting level of the list. Warning: Do not use this attribute, as it has been deprecated; use the CSS list-style-type property instead. */
-  "type": (value: string) => HTMLElements["ul"];
-} & GlobalAriaAttributes<"ul"> & GlobalHTMLAttributes<"ul">;
+  type: (value: string) => HTMLElements["ul"];
+} & GlobalAriaAttributes<"ul"> &
+  GlobalHTMLAttributes<"ul">;
 
 type varElement = {
-  "role": (value: string) => HTMLElements["var"];
-} & GlobalAriaAttributes<"var"> & GlobalHTMLAttributes<"var">;
+  role: (value: string) => HTMLElements["var"];
+} & GlobalAriaAttributes<"var"> &
+  GlobalHTMLAttributes<"var">;
 
 type videoElement = {
   /** A Boolean attribute which if true indicates that the element should automatically toggle picture-in-picture mode when the user switches back and forth between this document and another document or application. */
-  "autopictureinpicture": (value: string) => HTMLElements["video"];
+  autopictureinpicture: (value: string) => HTMLElements["video"];
   /** A Boolean attribute; if specified, the video automatically begins to play back as soon as it can do so without stopping to finish loading the data. Note: Sites that automatically play audio (or videos with an audio track) can be an unpleasant experience for users, so should be avoided when possible. If you must offer autoplay functionality, you should make it opt-in (requiring a user to specifically enable it). However, this can be useful when creating media elements whose source will be set at a later time, under user control. See our autoplay guide for additional information about how to properly use autoplay. To disable video autoplay, autoplay="false" will not work; the video will autoplay if the attribute is there in the <video> tag at all. To remove autoplay, the attribute needs to be removed altogether. In some browsers (e.g. Chrome 70.0) autoplay doesn't work if no muted attribute is present. */
-  "autoplay": (value: boolean) => HTMLElements["video"];
+  autoplay: (value: boolean) => HTMLElements["video"];
   /** If this attribute is present, the browser will offer controls to allow the user to control video playback, including volume, seeking, and pause/resume playback. */
-  "controls": (value: boolean) => HTMLElements["video"];
-  "controlslist": (value: string) => HTMLElements["video"];
+  controls: (value: boolean) => HTMLElements["video"];
+  controlslist: (value: string) => HTMLElements["video"];
   /** This enumerated attribute indicates whether to use CORS to fetch the related video. CORS-enabled resources can be reused in the <canvas> element without being tainted. The allowed values are: anonymous Sends a cross-origin request without a credential. In other words, it sends the Origin: HTTP header without a cookie, X.509 certificate, or performing HTTP Basic authentication. If the server does not give credentials to the origin site (by not setting the Access-Control-Allow-Origin: HTTP header), the image will be tainted, and its usage restricted. use-credentials Sends a cross-origin request with a credential. In other words, it sends the Origin: HTTP header with a cookie, a certificate, or performing HTTP Basic authentication. If the server does not give credentials to the origin site (through Access-Control-Allow-Credentials: HTTP header), the image will be tainted and its usage restricted. When not present, the resource is fetched without a CORS request (i.e. without sending the Origin: HTTP header), preventing its non-tainted used in <canvas> elements. If invalid, it is handled as if the enumerated keyword anonymous was used. See CORS settings attributes for additional information. */
-  "crossorigin": (value: "" | "anonymous" | "use-credentials") => HTMLElements["video"];
+  crossorigin: (
+    value: "" | "anonymous" | "use-credentials"
+  ) => HTMLElements["video"];
   /** Prevents the browser from suggesting a Picture-in-Picture context menu or to request Picture-in-Picture automatically in some cases. */
-  "disablepictureinpicture": (value: string) => HTMLElements["video"];
+  disablepictureinpicture: (value: string) => HTMLElements["video"];
   /** A Boolean attribute used to disable the capability of remote playback in devices that are attached using wired (HDMI, DVI, etc.) and wireless technologies (Miracast, Chromecast, DLNA, AirPlay, etc). In Safari, you can use x-webkit-airplay="deny" as a fallback. */
-  "disableremoteplayback": (value: string) => HTMLElements["video"];
+  disableremoteplayback: (value: string) => HTMLElements["video"];
   /** The height of the video's display area, in CSS pixels (absolute values only; no percentages.) */
-  "height": (value: number) => HTMLElements["video"];
+  height: (value: number) => HTMLElements["video"];
   /** A Boolean attribute; if specified, the browser will automatically seek back to the start upon reaching the end of the video. */
-  "loop": (value: boolean) => HTMLElements["video"];
+  loop: (value: boolean) => HTMLElements["video"];
   /** A Boolean attribute that indicates the default setting of the audio contained in the video. If set, the audio will be initially silenced. Its default value is false, meaning that the audio will be played when the video is played. */
-  "muted": (value: boolean) => HTMLElements["video"];
-  "playsinline": (value: boolean) => HTMLElements["video"];
-  "poster": (value: string) => HTMLElements["video"];
+  muted: (value: boolean) => HTMLElements["video"];
+  playsinline: (value: boolean) => HTMLElements["video"];
+  poster: (value: string) => HTMLElements["video"];
   /** This enumerated attribute is intended to provide a hint to the browser about what the author thinks will lead to the best user experience with regards to what content is loaded before the video is played. It may have one of the following values: none: Indicates that the video should not be preloaded. metadata: Indicates that only video metadata (e.g. length) is fetched. auto: Indicates that the whole video file can be downloaded, even if the user is not expected to use it. empty string: Synonym of the auto value. The default value is different for each browser. The spec advises it to be set to metadata. Note: The autoplay attribute has precedence over preload. If autoplay is specified, the browser would obviously need to start downloading the video for playback. The specification does not force the browser to follow the value of this attribute; it is a mere hint. */
-  "preload": (value: "none" | "metadata" | "auto") => HTMLElements["video"];
-  "role": (value: string) => HTMLElements["video"];
+  preload: (value: "none" | "metadata" | "auto") => HTMLElements["video"];
+  role: (value: string) => HTMLElements["video"];
   /** The URL of the video to embed. This is optional; you may instead use the <source> element within the video block to specify the video to embed. */
-  "src": (value: string) => HTMLElements["video"];
+  src: (value: string) => HTMLElements["video"];
   /** The width of the video's display area, in CSS pixels (absolute values only; no percentages). */
-  "width": (value: number) => HTMLElements["video"];
-} & GlobalAriaAttributes<"video"> & GlobalHTMLAttributes<"video">;
+  width: (value: number) => HTMLElements["video"];
+} & GlobalAriaAttributes<"video"> &
+  GlobalHTMLAttributes<"video">;
 
 type wbrElement = {
-  "role": (value: string) => HTMLElements["wbr"];
-} & GlobalAriaAttributes<"wbr"> & GlobalHTMLAttributes<"wbr">;
+  role: (value: string) => HTMLElements["wbr"];
+} & GlobalAriaAttributes<"wbr"> &
+  GlobalHTMLAttributes<"wbr">;
 
-type xmpElement = {
-} & GlobalAriaAttributes<"xmp"> & GlobalHTMLAttributes<"xmp">;
+type xmpElement = {} & GlobalAriaAttributes<"xmp"> &
+  GlobalHTMLAttributes<"xmp">;

--- a/packages/hdot/src/types/index.ts
+++ b/packages/hdot/src/types/index.ts
@@ -1,0 +1,20 @@
+export * from "./html";
+
+type Tree = (TreeNode | string)[];
+export type TreeNode = {
+  tag: string;
+  attrs: {
+    [key: string]: string;
+  };
+  content: Tree;
+};
+
+export type TransformerPlugin = {
+  (tree: TreeNode): TreeNode;
+};
+export type SerializerPlugin = {
+  (tree: TreeNode): string;
+};
+export type PluginArray =
+  | [...TransformerPlugin[], SerializerPlugin]
+  | TransformerPlugin[];

--- a/packages/hdot/src/types/index.ts
+++ b/packages/hdot/src/types/index.ts
@@ -1,3 +1,6 @@
+import { BaseHTMLElements } from "./html";
+
+// import { HTMLElements, GlobalAriaAttributes, GlobalHTMLAttributes } from "./html";
 export * from "./html";
 
 type Tree = (TreeNode | string)[];
@@ -18,3 +21,46 @@ export type SerializerPlugin = {
 export type PluginArray =
   | [...TransformerPlugin[], SerializerPlugin]
   | TransformerPlugin[];
+
+// export type MapCustomElements<CustomElements> = {
+//   [TagName in keyof CustomElements]: {
+//     [AttributeName in keyof CustomElements[TagName]]: (value: CustomElements[TagName][AttributeName]) => HTMLElements<CustomElements>[TagName];
+//   }
+// }
+
+// export type HTMLElements = BaseHTMLElements & HTMLElementTagNameMap
+
+// type HTMLElementTagNameMap = (globalThis.HTMLElementTagNameMap extends never ? {} : globalThis.HTMLElementTagNameMap)
+
+// export type MapCustomElements = {
+//   [TagName in keyof HTMLElementTagNameMap]: {
+//     [AttributeName in keyof HTMLElementTagNameMap[TagName]]: (value: HTMLElementTagNameMap[TagName][AttributeName]) => HTMLElements<CustomElements>[TagName];
+//   }
+// }
+
+// export type AddGlobalAttributes<CustomElements> = {
+//   [TagName in keyof CustomElements]: CustomElements[TagName] & GlobalAriaAttributes<CustomElements[TagName]> & GlobalHTMLAttributes<CustomElements[TagName]> 
+// }
+
+// type CustomElements = {
+//   /**
+//    * @description nice
+//    */
+//   "myElement": {
+//     /**
+//      * wooohooo
+//      * @description lets gooo
+//      * @link https://willmartian.com
+//      */
+//     testy: string;
+//   }
+// }
+
+type g = globalThis.HTMLElementTagNameMap
+
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'my-element': 5;
+  }
+}

--- a/packages/hdot/src/utils.ts
+++ b/packages/hdot/src/utils.ts
@@ -15,3 +15,21 @@ export const isTemplateParam = (...args: any[]): boolean => {
   );
   //&& Array.isArray(args[1]);
 };
+
+/**
+ * @todo investigate better ways of doing this.
+ * Maybe make a reusable "ProxiedClass"?
+ * @link https://stackoverflow.com/questions/51865430/typescript-compiler-does-not-know-about-es6-proxy-trap-on-class
+ */
+export function fakeBaseClass<T>(): new () => Pick<T, keyof T> {
+  return class {} as any;
+}
+
+/**
+ * @param key An object's property key we are trying to access
+ * @param omitted Keys on which we Reflect the default behavior
+ */
+export const keyIsOmitted = (
+  key: string | symbol,
+  ...omitted: string[]
+): key is symbol => typeof key !== "string" || omitted.includes(key);

--- a/packages/hdot/src/utils.ts
+++ b/packages/hdot/src/utils.ts
@@ -17,15 +17,6 @@ export const isTemplateParam = (...args: any[]): boolean => {
 };
 
 /**
- * @todo investigate better ways of doing this.
- * Maybe make a reusable "ProxiedClass"?
- * @link https://stackoverflow.com/questions/51865430/typescript-compiler-does-not-know-about-es6-proxy-trap-on-class
- */
-export function fakeBaseClass<T>(): new () => Pick<T, keyof T> {
-  return class {} as any;
-}
-
-/**
  * @param key An object's property key we are trying to access
  * @param omitted Keys on which we Reflect the default behavior
  */

--- a/packages/hdot/test/hdot.test.ts
+++ b/packages/hdot/test/hdot.test.ts
@@ -3,53 +3,71 @@ import * as assert from "uvu/assert";
 import { h } from "../src/hdot";
 
 test("basic", () => {
-  assert.equal(h.div(), "<div></div>");
-  assert.equal(h.h1(), "<h1></h1>");
+  assert.equal(h.div.toString(), "<div></div>");
+  assert.equal(h.div().toString(), "<div></div>");
+  assert.equal(h.h1().toString(), "<h1></h1>");
   assert.equal(h.p.toString(), "<p></p>");
 });
 
 test("children", () => {
-  assert.equal(h.div("hdot"), "<div>hdot</div>");
-  assert.equal(h.div`hdot`, "<div>hdot</div>");
-  assert.equal(h.div(h.div()), "<div><div></div></div>");
-  assert.equal(h.div(h.div("hdot")), "<div><div>hdot</div></div>");
-  assert.equal(h.div(h.div("hdot"), "hdot"), "<div><div>hdot</div>hdot</div>");
+  assert.equal(h.div("hdot").toString(), "<div>hdot</div>");
+  assert.equal(h.div`hdot`.toString(), "<div>hdot</div>");
+  assert.equal(h.div(h.div()).toString(), "<div><div></div></div>");
+  assert.equal(h.div(h.div("hdot")).toString(), "<div><div>hdot</div></div>");
   assert.equal(
-    h.div(h.div, h.div(), h.div.toString(), h.div().toString(), h.div``),
+    h.div(h.div("hdot"), "hdot").toString(),
+    "<div><div>hdot</div>hdot</div>"
+  );
+  assert.equal(
+    h
+      .div(h.div, h.div(), h.div.toString(), h.div().toString(), h.div``)
+      .toString(),
     "<div><div></div><div></div><div></div><div></div><div></div></div>"
   );
   assert.equal(
-    h.div`Hello ${h.span`world!`}`,
+    h.div`Hello ${h.span`world!`}`.toString(),
     "<div>Hello <span>world!</span></div>"
   );
   assert.equal(
-    h.div(`Hello ${h.span`world!`}`),
+    h.div(`Hello ${h.span`world!`}`).toString(),
     "<div>Hello <span>world!</span></div>"
   );
-  assert.equal(h.div(`Hello ${h.span}`), "<div>Hello <span></span></div>");
+  assert.equal(
+    h.div(`Hello ${h.span}`).toString(),
+    "<div>Hello <span></span></div>"
+  );
 });
 
 test("attributes", () => {
-  assert.equal(h.div.id("hdot")(), '<div id="hdot"></div>');
+  assert.equal(h.div.id("hdot")().toString(), '<div id="hdot"></div>');
   assert.equal(h.h1.id("hdot").toString(), '<h1 id="hdot"></h1>');
   assert.equal(
     h.h1.id("hdot1").class("hdot2").toString(),
     '<h1 id="hdot1" class="hdot2"></h1>'
   );
-  assert.equal(h.details.open(true)(), "<details open></details>");
+  assert.equal(h.details.open(true)().toString(), "<details open></details>");
   assert.equal(
-    h.details.open(true).class("hdot")(),
+    h.details.open(true).class("hdot")().toString(),
     '<details open class="hdot"></details>'
   );
 });
 
 test("data attributes", () => {
-  assert.equal(h.div.dataName('test123')(), `<div data-name="test123"></div>`);
+  assert.equal(
+    h.div.dataName("test123")().toString(),
+    `<div data-name="test123"></div>`
+  );
 });
 
 test("aria attributes", () => {
-  assert.equal(h.div.ariaLabel('test123')(), `<div aria-label="test123"></div>`);
-  assert.equal(h.div.ariaLabel('test123').ariaChecked('false')(), `<div aria-label="test123" aria-checked="false"></div>`);
+  assert.equal(
+    h.div.ariaLabel("test123")().toString(),
+    `<div aria-label="test123"></div>`
+  );
+  assert.equal(
+    h.div.ariaLabel("test123").ariaChecked("false")().toString(),
+    `<div aria-label="test123" aria-checked="false"></div>`
+  );
 });
 
 test.run();

--- a/packages/plugins/validate/CHANGELOG.md
+++ b/packages/plugins/validate/CHANGELOG.md
@@ -7,10 +7,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @hdot/validate
 
-
-
-
-
 ## [0.0.6](https://github.com/willmartian/hdot/compare/@hdot/validate@0.0.5...@hdot/validate@0.0.6) (2022-03-29)
 
 **Note:** Version bump only for package @hdot/validate

--- a/packages/plugins/validate/test/validate.test.ts
+++ b/packages/plugins/validate/test/validate.test.ts
@@ -4,7 +4,7 @@ import { hdot } from "hdot";
 import validate from "../src/validate";
 
 test("basic", () => {
-  const h = new hdot([validate]);
+  const h = hdot([validate]);
 
   assert.throws(() => {
     h.div.id("hello world").toString();

--- a/packages/plugins/validate/test/validate.test.ts
+++ b/packages/plugins/validate/test/validate.test.ts
@@ -1,6 +1,18 @@
 import { test } from "uvu";
 import * as assert from "uvu/assert";
+import { hdot } from "hdot";
+import validate from "../src/validate";
 
 test("basic", () => {
-  // TODO
+  const h = new hdot([validate]);
+
+  assert.throws(() => {
+    h.div.id("hello world").toString();
+  });
+
+  assert.not.throws(() => {
+    h.div.id("helloworld").toString();
+  });
 });
+
+test.run();


### PR DESCRIPTION
This PR rewrites a good bit of the core logic.

## Before
Before, every `get` on `h` would append to `this.htmlString: string` internally, and calling the resulting function would return that string:

```js
h.div.id("test")(
  h.p`Hello world`
) === `<div id="test"><p>Hello world</p></div>`
```

## After this PR
Now, instead of passing `this.htmlString` around and appending to it, we pass around `this.tree`, which has the same type signature as https://posthtml.org/#/tree.

Furthermore, calling the resulting function will no longer return an HTML string, but return the h instance itself. Instead, one must manually call `toString` on the outermost function to get an HTML string.

```js
h.div.id("test")(
  h.p`Hello world`
).toString() === `<div id="test"><p>Hello world</p></div>`
```

# Why make this change? It is more verbose.

In the first code block, hdot functions are stringified from the inside out. `h.p` is converted to an HTML string, which is passed as a child to `h.div`.  This has a major ramification: parent elements can not inspect the content of their children without complex string manipulation. 

The new logic builds **one** tree structure, and then only stringifies **once** from the top down, when the dev calls `toString`. 

## Plugins

This enables plugins to do a lot more. Since the tree structure is the same as postHTML's, plugins should be mostly interoperable with a few more changes. Plugins will now only run once per tree, which should be a performance boost. 

TODO: add more plugin docs